### PR TITLE
Add info tool

### DIFF
--- a/cmd/k6-mcp/main.go
+++ b/cmd/k6-mcp/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/k6-mcp/internal/handlers"
 	"github.com/grafana/k6-mcp/internal/k6env"
 	"github.com/grafana/k6-mcp/internal/logging"
+	"github.com/grafana/k6-mcp/tools"
 )
 
 var serveStdio = server.ServeStdio
@@ -67,6 +68,7 @@ func run(ctx context.Context, logger *slog.Logger, stderr io.Writer) int {
 	)
 
 	// Register tools
+	tools.RegisterInfoTool(s)
 	registerRunTool(s, handlers.WithToolMiddleware("run_k6_script", handlers.NewRunHandler()))
 	registerDocumentationTools(s, handlers.WithToolMiddleware("search_k6_documentation", handlers.NewFullTextSearchHandler(db)))
 	registerValidationTool(s, handlers.WithToolMiddleware("validate_k6_script", handlers.NewValidationHandler()))

--- a/internal/k6env/detect_test.go
+++ b/internal/k6env/detect_test.go
@@ -59,7 +59,7 @@ func TestInfoVersion(t *testing.T) {
 		t.Fatalf("Version returned error: %v", err)
 	}
 
-	expected := "k6 v0.0.0-test"
+	expected := "0.0.0"
 	if version != expected {
 		t.Fatalf("Version = %q, want %q (stub path: %s)", version, expected, path)
 	}

--- a/internal/k6env/login.go
+++ b/internal/k6env/login.go
@@ -1,0 +1,34 @@
+package k6env
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// IsLoggedIn checks whether the k6 executable has an active k6 Cloud login.
+func (i Info) IsLoggedIn(ctx context.Context) (bool, error) {
+	if i.Path == "" {
+		return false, errors.New("k6 executable path is empty")
+	}
+
+	// #nosec G204 -- i.Path is obtained from Locate and points to a trusted executable
+	cmd := exec.CommandContext(ctx, i.Path, "cloud", "login", "--show")
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to get k6 version: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(output))
+
+	re := regexp.MustCompile(`(?m)^\s*token:\s*([0-9a-fA-F]{64})\s*$`)
+	if !re.MatchString(raw) {
+		return false, fmt.Errorf("missing token line in output:\n%s", raw)
+	}
+	token := re.FindStringSubmatch(raw)[1]
+
+	return token != "", nil
+}

--- a/internal/k6env/version.go
+++ b/internal/k6env/version.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 )
 
 // Version executes "k6 version" using the resolved executable path.
-// It returns the trimmed stdout string (e.g., "k6 v0.47.0 (...)").
+// It returns only the semantic version (e.g., "1.3.0"). If no semver is found,
+// the raw trimmed output is returned.
 func (i Info) Version(ctx context.Context) (string, error) {
 	if i.Path == "" {
 		return "", errors.New("k6 executable path is empty")
@@ -22,5 +24,16 @@ func (i Info) Version(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to get k6 version: %w", err)
 	}
 
-	return strings.TrimSpace(string(output)), nil
+	raw := strings.TrimSpace(string(output))
+
+	// Extract semantic version (e.g., 1.3.0) from outputs like:
+	// "k6 v1.3.0 (commit/devel, go1.25.1, darwin/arm64)" or "k6 v0.0.0-test"
+	// We prefer strict semver (MAJOR.MINOR.PATCH). If not found, fall back to the raw string.
+	// The regex captures the first x.y.z sequence optionally prefixed by v.
+	semverRe := regexp.MustCompile(`\bv?(\d+\.\d+\.\d+)\b`)
+	if m := semverRe.FindStringSubmatch(raw); len(m) == 2 {
+		return m[1], nil
+	}
+
+	return raw, nil
 }

--- a/tools/info.go
+++ b/tools/info.go
@@ -1,0 +1,77 @@
+// Package tools contains MCP tool definitions exposed by the k6-mcp server.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/grafana/k6-mcp/internal/buildinfo"
+	"github.com/grafana/k6-mcp/internal/k6env"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// InfoTool exposes runtime information about k6-mcp and the local k6 environment.
+//
+//nolint:gochecknoglobals // Shared tool definition registered at startup.
+var InfoTool = mcp.NewTool(
+	"info",
+	mcp.WithDescription("Get details about the k6-mcp server, the local k6 binary, and k6 Cloud login status."),
+)
+
+// RegisterInfoTool registers the info tool with the MCP server.
+func RegisterInfoTool(s *server.MCPServer) {
+	s.AddTool(InfoTool, info)
+}
+
+func info(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Locate the k6 executable
+	k6Info, err := k6env.Locate(ctx)
+	if err != nil {
+		//nolint:nilerr // Error is reported via the MCP error result.
+		return mcp.NewToolResultError("Failed to locate k6 executable on the user's system; reason: " + err.Error()), nil
+	}
+
+	// Extract the located k6 binary's k6Version
+	k6Version, err := k6Info.Version(ctx)
+	if err != nil {
+		//nolint:nilerr // Error is reported via the MCP error result.
+		return mcp.NewToolResultError("Failed to get user's k6 binary version; reason: " + err.Error()), nil
+	}
+
+	// Check if the user is logged in to k6 cloud
+	isLoggedIn, err := k6Info.IsLoggedIn(ctx)
+	if err != nil {
+		//nolint:nilerr // Error is reported via the MCP error result.
+		return mcp.NewToolResultError("Failed to check if k6 is logged in; reason: " + err.Error()), nil
+	}
+
+	// Create the response
+	response := InfoResponse{
+		Version:   buildinfo.Version,
+		K6Version: k6Version,
+		LoggedIn:  isLoggedIn,
+	}
+
+	// Marshal the response to JSON
+	jsonResponse, err := json.Marshal(response)
+	if err != nil {
+		//nolint:nilerr // Error is reported via the MCP error result.
+		return mcp.NewToolResultError("Failed to marshal info response; reason: " + err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(string(jsonResponse)), nil
+}
+
+// InfoResponse is the response to the info tool.
+type InfoResponse struct {
+	// Version is the version of the k6-mcp server.
+	Version string `json:"version"`
+
+	// K6Version is the version of the k6 binary present in the system and
+	// being used by the server.
+	K6Version string `json:"k6_version"`
+
+	// LoggedIn is a boolean indicating if the user is logged in to k6 cloud.
+	LoggedIn bool `json:"logged_in"`
+}


### PR DESCRIPTION
This pull request introduces a new "info" tool to the k6-mcp server, which provides details about the server, the k6 binary version, and the user's k6 cloud login status. It also refines how the k6 binary version is detected, ensuring only the semantic version is returned, and adds the ability to check the user's cloud login status. There are also minor updates to related tests and utility files.

**Note** that this tool adopts a similar design to the Grafana MCP server, to better align our implementation and practices with them to facilitate a potential future merge.

**New Info Tool Integration:**

* Added the `info` tool in `tools/info.go`, which reports server version, k6 binary version, and k6 cloud login status via a structured JSON response.
* Registered the new info tool in the main server setup within `cmd/k6-mcp/main.go`. [[1]](diffhunk://#diff-aabe31d8fd78a9a1e39a0f61dd5a52b892c0f16028c8e858addcd7539e52f912R27) [[2]](diffhunk://#diff-aabe31d8fd78a9a1e39a0f61dd5a52b892c0f16028c8e858addcd7539e52f912R71)

**Improvements to k6 Binary Detection:**

* Updated `internal/k6env/version.go` so that the `Version` method extracts and returns only the semantic version (e.g., `1.3.0`) from the k6 binary output instead of the raw string. [[1]](diffhunk://#diff-f9be7eae975336fa1319d9a953bf58b4dcabdba8650dfa721c2b84d16d6daee7R8-R14) [[2]](diffhunk://#diff-f9be7eae975336fa1319d9a953bf58b4dcabdba8650dfa721c2b84d16d6daee7L25-R38)
* Modified the corresponding test in `internal/k6env/detect_test.go` to expect the new version format.

**User Login Status Detection:**

* Added `internal/k6env/login.go` with an `IsLoggedIn` method to check if the user is logged in to k6 cloud by parsing the output of `k6 cloud login --show`.

**Utility File Updates:**

* Updated utility files `count` and `wc` with new hashes, likely for tracking or build purposes. [[1]](diffhunk://#diff-6c35493a2b937829c9815c39e23af964bc84e5430a7dc104c700bbc0de2b59e3R1) [[2]](diffhunk://#diff-9c7d3cc1bee7acc045c697d6d56fd8d9a1732f31ccd59c2a56872456e648f72dR1)