### PR TITLE
Readme polishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ Download and install the `.deb` package from the [latest release](https://github
 ```bash
 # For amd64 (x86_64)
 curl -LO https://github.com/grafana/mcp-k6/releases/latest/download/mcp-k6_VERSION_linux_amd64.deb
-sudo dpkg -i mcp-k6_*_linux_amd64.deb
+sudo dpkg -i mcp-k6_0.2.0_linux_amd64.deb
 
 # For arm64
 curl -LO https://github.com/grafana/mcp-k6/releases/latest/download/mcp-k6_VERSION_linux_arm64.deb
-sudo dpkg -i mcp-k6_*_linux_arm64.deb
+sudo dpkg -i mcp-k6_0.2.0_linux_arm64.deb
 ```
 
 Or install directly with `apt`:
@@ -87,7 +87,7 @@ Or install directly with `apt`:
 curl -LO https://github.com/grafana/mcp-k6/releases/latest/download/mcp-k6_VERSION_linux_amd64.deb
 
 # Install with apt (resolves dependencies)
-sudo apt install ./mcp-k6_*_linux_amd64.deb
+sudo apt install ./mcp-k6_0.2.0_linux_amd64.deb
 ```
 
 #### RHEL/Fedora/CentOS (.rpm)
@@ -97,11 +97,11 @@ Download and install the `.rpm` package from the [latest release](https://github
 ```bash
 # For amd64 (x86_64)
 curl -LO https://github.com/grafana/mcp-k6/releases/latest/download/mcp-k6_VERSION_linux_amd64.rpm
-sudo rpm -i mcp-k6_*_linux_amd64.rpm
+sudo rpm -i mcp-k6_0.2.0_linux_amd64.rpm
 
 # For arm64
 curl -LO https://github.com/grafana/mcp-k6/releases/latest/download/mcp-k6_VERSION_linux_arm64.rpm
-sudo rpm -i mcp-k6_*_linux_arm64.rpm
+sudo rpm -i mcp-k6_0.2.0_linux_arm64.rpm
 ```
 
 Or use `dnf`/`yum`:


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to simplify and clarify the process for installing `mcp-k6` across different platforms. The changes mainly focus on improving the Homebrew installation steps and specifying exact package filenames for Linux distributions.

**Installation instructions improvements:**

* Updated the Homebrew installation steps to use the official `grafana/grafana` tap and simplified the instructions, removing outdated steps for downloading the formula manually.
* Changed Linux `.deb` and `.rpm` installation commands to use explicit versioned filenames (`mcp-k6_0.2.0_linux_amd64.deb` and `mcp-k6_0.2.0_linux_amd64.rpm`), instead of wildcard patterns, for clarity and accuracy. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R90) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R104)