### PR TITLE
Restore Streamable HTTP transport support

### DIFF
--- a/cmd/mcp-k6/main_test.go
+++ b/cmd/mcp-k6/main_test.go
@@ -20,7 +20,7 @@ func TestRunFailsWhenK6Missing(t *testing.T) {
 	logger := newTestLogger()
 	var stderr bytes.Buffer
 
-	code := run(context.Background(), logger, &stderr)
+	code := run(context.Background(), logger, &stderr, nil)
 	assert.NotEqual(t, 0, code, "run should return non-zero exit code when k6 is missing")
 	assert.Contains(t, stderr.String(), "mcp-k6 requires the `k6` executable")
 }
@@ -45,7 +45,7 @@ func TestRunSucceedsWithStubbedK6(t *testing.T) {
 	logger := newTestLogger()
 	var stderr bytes.Buffer
 
-	code := run(context.Background(), logger, &stderr)
+	code := run(context.Background(), logger, &stderr, nil)
 	assert.Equal(t, 0, code, "run should succeed when k6 is available")
 }
 


### PR DESCRIPTION
This pull request adds command-line flag support to the `mcp-k6` server, enabling flexible configuration of transport mode, HTTP address, endpoint path, and stateless operation. The main entrypoint and server initialization logic are refactored to accommodate these new options. Additionally, tests are updated to reflect the new function signature.

Flag and transport configuration:

* Introduced the `flag` package to parse command-line arguments, allowing users to select transport mode (`stdio` or `http`), HTTP address, endpoint path, and stateless mode for the server via flags in `cmd/mcp-k6/main.go`. [[1]](diffhunk://#diff-1948577b65b939e31bdeaddf16bc0cb2ce571d609b2d0f52d425ab19e9166a47R7) [[2]](diffhunk://#diff-1948577b65b939e31bdeaddf16bc0cb2ce571d609b2d0f52d425ab19e9166a47L42-L45)
* Refactored the `run` function to accept an `args` parameter, parse flags, and initialize the server according to the chosen transport mode. If `http` is selected, the server starts with the specified options; otherwise, it defaults to stdio. [[1]](diffhunk://#diff-1948577b65b939e31bdeaddf16bc0cb2ce571d609b2d0f52d425ab19e9166a47L42-L45) [[2]](diffhunk://#diff-1948577b65b939e31bdeaddf16bc0cb2ce571d609b2d0f52d425ab19e9166a47R84-R108)

Test updates:

* Updated test invocations of `run` to pass the new `args` parameter, ensuring compatibility with the refactored function signature in `cmd/mcp-k6/main_test.go`. [[1]](diffhunk://#diff-9eb0baf6e4910fdf191c3609d75d117c880057d26571654dcc8d440d647748dcL23-R23) [[2]](diffhunk://#diff-9eb0baf6e4910fdf191c3609d75d117c880057d26571654dcc8d440d647748dcL48-R48)