### PR TITLE
Expose mcp server functionalities as package

### DIFF
--- a/cmd/mcp-k6/main.go
+++ b/cmd/mcp-k6/main.go
@@ -3,180 +3,32 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
-	"fmt"
-	"io"
-	"log/slog"
 	"os"
 
-	"github.com/mark3labs/mcp-go/server"
-
-	k6mcp "github.com/grafana/mcp-k6"
-	"github.com/grafana/mcp-k6/internal/buildinfo"
-	"github.com/grafana/mcp-k6/internal/k6env"
 	"github.com/grafana/mcp-k6/internal/logging"
-	"github.com/grafana/mcp-k6/internal/sections"
-	"github.com/grafana/mcp-k6/prompts"
-	"github.com/grafana/mcp-k6/resources"
-	"github.com/grafana/mcp-k6/tools"
+	"github.com/grafana/mcp-k6/mcpserver"
 )
-
-// Server instructions are a good opportunity to give the agent a high-level overview of the tools
-// and resources that will be made available. However, it should be kept as brief as possible, as
-// to not waste conversation tokens.
-const instructions = `
-Use the provided tools for running or validating k6 scripts, for browsing the k6 OSS docs, or
-for searching for k6 Cloud-related Terraform resources in the Grafana Terraform provider.
-Use the provided resources for understanding the k6 script authoring best practices and for consulting
-type definitions.
-List the resources at least once before trying to access one of them.
-Use the provided prompts as a good starting point for authoring complex k6 scripts.
-`
-
-//nolint:gochecknoglobals // Allows test override for stdio server.
-var serveStdio = server.ServeStdio
 
 func main() {
 	logger := logging.Default()
-	//nolint:forbidigo // main must exit with the server status code.
-	os.Exit(run(context.Background(), logger, os.Stderr, os.Args[1:]))
-}
 
-func run(ctx context.Context, logger *slog.Logger, stderr io.Writer, args []string) int {
+	cfg := mcpserver.DefaultConfig()
+
 	fs := flag.NewFlagSet("mcp-k6", flag.ContinueOnError)
-	fs.SetOutput(stderr)
+	//nolint:forbidigo // main must write to stderr.
+	fs.SetOutput(os.Stderr)
 
-	var (
-		transport = fs.String("transport", "stdio", "Transport mode: stdio or http")
-		addr      = fs.String("addr", ":8080", "HTTP address to listen on")
-		endpoint  = fs.String("endpoint", "/mcp", "Endpoint path for HTTP transport")
-		stateless = fs.Bool("stateless", false, "Run in stateless mode (no session tracking)")
-	)
+	fs.StringVar(&cfg.Transport, "transport", cfg.Transport, "Transport mode: stdio or http")
+	fs.StringVar(&cfg.Addr, "addr", cfg.Addr, "HTTP address to listen on")
+	fs.StringVar(&cfg.Endpoint, "endpoint", cfg.Endpoint, "Endpoint path for HTTP transport")
+	fs.BoolVar(&cfg.Stateless, "stateless", cfg.Stateless, "Run in stateless mode (no session tracking)")
 
-	if err := fs.Parse(args); err != nil {
-		return 1
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		//nolint:forbidigo // main must exit with the server status code.
+		os.Exit(1)
 	}
 
-	logger.Info("Starting k6 MCP server",
-		slog.String("version", buildinfo.Version),
-		slog.String("commit", buildinfo.Commit),
-		slog.String("built_at", buildinfo.Date),
-		slog.Bool("resource_capabilities", true),
-	)
-
-	k6Info, err := k6env.Locate(ctx)
-	if err != nil {
-		return handleK6LookupError(logger, stderr, err)
-	}
-
-	logger.Info("Detected k6 executable", slog.String("path", k6Info.Path))
-
-	finder, err := loadSectionsIndex(logger)
-	if err != nil {
-		logger.Error("Failed to load sections index", slog.String("error", err.Error()))
-		return 1
-	}
-
-	// Create and wire up the MCP server instance.
-	s := createServer(finder)
-
-	if *transport == "http" {
-		httpOpts := []server.StreamableHTTPOption{
-			server.WithEndpointPath(*endpoint),
-		}
-
-		if *stateless {
-			httpOpts = append(httpOpts, server.WithStateLess(true))
-		}
-
-		httpServer := server.NewStreamableHTTPServer(s, httpOpts...)
-
-		logger.Info("Starting MCP server with Streamable HTTP",
-			slog.String("addr", *addr),
-			slog.String("endpoint", *endpoint),
-			slog.Bool("stateless", *stateless),
-		)
-
-		if err := httpServer.Start(*addr); err != nil {
-			logger.Error("Server error", slog.String("error", err.Error()))
-			_, _ = fmt.Fprintf(stderr, "MCP server exited with error: %v\n", err)
-			return 1
-		}
-		return 0
-	}
-
-	logger.Info("Starting MCP server on stdio")
-	if err := serveStdio(s); err != nil {
-		logger.Error("Server error", slog.String("error", err.Error()))
-		_, _ = fmt.Fprintf(stderr, "MCP server exited with error: %v\n", err)
-		return 1
-	}
-
-	return 0
-}
-
-func createServer(finder *sections.Finder) *server.MCPServer {
-	s := server.NewMCPServer(
-		"k6",
-		buildinfo.Version,
-		server.WithResourceCapabilities(true, true),
-		server.WithLogging(),
-		server.WithRecovery(),
-		server.WithInstructions(instructions),
-	)
-
-	// Register tools
-	tools.RegisterInfoTool(s)
-	tools.RegisterValidateTool(s)
-	tools.RegisterRunTool(s)
-	tools.RegisterSearchTerraformTool(s)
-	tools.RegisterListSectionsTool(s, finder)
-	tools.RegisterGetDocumentationTool(s, finder)
-
-	// Register resources
-	resources.RegisterBestPracticesResource(s)
-	resources.RegisterTypeDefinitionsResources(s)
-
-	// Register prompts
-	prompts.RegisterGenerateScriptPrompt(s)
-	prompts.RegisterConvertPlaywrightScriptPrompt(s)
-
-	return s
-}
-
-func loadSectionsIndex(logger *slog.Logger) (*sections.Finder, error) {
-	// Load sections index
-	logger.Info("Loading sections index")
-	sectionsIdx, err := sections.LoadJSON(k6mcp.SectionsIndex)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load sections index: %w", err)
-	}
-	finder := sections.NewFinder(sectionsIdx)
-
-	totalSections := 0
-	for _, secs := range sectionsIdx.Sections {
-		totalSections += len(secs)
-	}
-	logger.Info("Loaded sections index",
-		slog.Int("version_count", len(sectionsIdx.Versions)),
-		slog.Int("total_sections", totalSections),
-		slog.String("latest_version", sectionsIdx.Latest))
-
-	return finder, nil
-}
-
-func handleK6LookupError(logger *slog.Logger, stderr io.Writer, err error) int {
-	if errors.Is(err, k6env.ErrNotFound) {
-		message := "mcp-k6 requires the `k6` executable on your PATH. Install k6 " +
-			"(https://grafana.com/docs/k6/latest/get-started/installation/) " +
-			"and ensure it is accessible before retrying."
-		logger.Error("k6 executable not found on PATH", slog.String("hint", message))
-		_, _ = fmt.Fprintln(stderr, message)
-	} else {
-		logger.Error("Failed to locate k6 executable", slog.String("error", err.Error()))
-		_, _ = fmt.Fprintf(stderr, "Failed to locate k6 executable: %v\n", err)
-	}
-
-	return 1
+	//nolint:forbidigo // main must exit with the server status code.
+	os.Exit(mcpserver.Run(context.Background(), logger, os.Stderr, cfg))
 }

--- a/cmd/mcp-k6/main.go
+++ b/cmd/mcp-k6/main.go
@@ -24,6 +24,7 @@ func main() {
 	fs.StringVar(&cfg.Endpoint, "endpoint", cfg.Endpoint, "Endpoint path for HTTP transport")
 	fs.BoolVar(&cfg.Stateless, "stateless", cfg.Stateless, "Run in stateless mode (no session tracking)")
 
+	//nolint:forbidigo // main must parse CLI arguments from os.Args.
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		//nolint:forbidigo // main must exit with the server status code.
 		os.Exit(1)

--- a/cmd/mcp-k6/main_test.go
+++ b/cmd/mcp-k6/main_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/mcp-k6/mcpserver"
 )
 
 func TestRunFailsWhenK6Missing(t *testing.T) {
@@ -20,7 +22,7 @@ func TestRunFailsWhenK6Missing(t *testing.T) {
 	logger := newTestLogger()
 	var stderr bytes.Buffer
 
-	code := run(context.Background(), logger, &stderr, nil)
+	code := mcpserver.Run(context.Background(), logger, &stderr, mcpserver.DefaultConfig())
 	assert.NotEqual(t, 0, code, "run should return non-zero exit code when k6 is missing")
 	assert.Contains(t, stderr.String(), "mcp-k6 requires the `k6` executable")
 }
@@ -34,18 +36,16 @@ func TestRunSucceedsWithStubbedK6(t *testing.T) {
 		t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
 	}
 
-	originalServe := serveStdio
-	serveStdio = func(*server.MCPServer, ...server.StdioOption) error {
+	stubServe := func(*server.MCPServer, ...server.StdioOption) error {
 		return nil
 	}
-	t.Cleanup(func() {
-		serveStdio = originalServe
-	})
 
 	logger := newTestLogger()
 	var stderr bytes.Buffer
 
-	code := run(context.Background(), logger, &stderr, nil)
+	code := mcpserver.Run(context.Background(), logger, &stderr, mcpserver.DefaultConfig(),
+		mcpserver.WithServeStdio(stubServe),
+	)
 	assert.Equal(t, 0, code, "run should succeed when k6 is available")
 }
 

--- a/cmd/prepare/main.go
+++ b/cmd/prepare/main.go
@@ -172,7 +172,7 @@ func cloneRepository(repoURL, targetDir string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", repoURL, targetDir)
+	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", repoURL, targetDir) // #nosec G204
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -253,7 +253,9 @@ func cloneTypesRepository(repoURL, repoDir string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "clone", "--filter=blob:none", "--sparse", "--depth=1", repoURL, repoDir)
+	cmd := exec.CommandContext( // #nosec G204
+		ctx, "git", "clone", "--filter=blob:none", "--sparse", "--depth=1", repoURL, repoDir,
+	)
 	var cloneStderr bytes.Buffer
 	cmd.Stderr = &cloneStderr
 	err := cmd.Run()
@@ -261,7 +263,9 @@ func cloneTypesRepository(repoURL, repoDir string) error {
 		return fmt.Errorf("failed to clone types repository; reason: %s", cloneStderr.String())
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "-C", repoDir, "sparse-checkout", "set", "types/k6")
+	cmd = exec.CommandContext( // #nosec G204
+		ctx, "git", "-C", repoDir, "sparse-checkout", "set", "types/k6",
+	)
 	var sparseStderr bytes.Buffer
 	cmd.Stderr = &sparseStderr
 	err = cmd.Run()
@@ -296,7 +300,7 @@ func cleanUpTypesRepository(repoDir string) error {
 			return nil
 		}
 		if !strings.HasSuffix(d.Name(), internal.DistDTSFileSuffix) {
-			if err := os.Remove(path); err != nil {
+			if err := os.Remove(path); err != nil { // #nosec G122
 				return fmt.Errorf("failed to remove file %s: %w", path, err)
 			}
 		}

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -1,0 +1,213 @@
+// Package mcpserver provides the k6 MCP server as a reusable library.
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/mark3labs/mcp-go/server"
+
+	k6mcp "github.com/grafana/mcp-k6"
+	"github.com/grafana/mcp-k6/internal/buildinfo"
+	"github.com/grafana/mcp-k6/internal/k6env"
+	"github.com/grafana/mcp-k6/internal/sections"
+	"github.com/grafana/mcp-k6/prompts"
+	"github.com/grafana/mcp-k6/resources"
+	"github.com/grafana/mcp-k6/tools"
+)
+
+// instructions is a high-level overview of the tools and resources available.
+const instructions = `
+Use the provided tools for running or validating k6 scripts, for browsing the k6 OSS docs, or
+for searching for k6 Cloud-related Terraform resources in the Grafana Terraform provider.
+Use the provided resources for understanding the k6 script authoring best practices and for consulting
+type definitions.
+List the resources at least once before trying to access one of them.
+Use the provided prompts as a good starting point for authoring complex k6 scripts.
+`
+
+// Config holds the MCP server configuration.
+type Config struct {
+	Transport string // "stdio" or "http" (default: "stdio")
+	Addr      string // HTTP listen address (default: ":8080")
+	Endpoint  string // HTTP endpoint path (default: "/mcp")
+	Stateless bool   // Stateless mode for HTTP
+}
+
+// DefaultConfig returns a Config with default values.
+func DefaultConfig() Config {
+	return Config{
+		Transport: "stdio",
+		Addr:      ":8080",
+		Endpoint:  "/mcp",
+	}
+}
+
+// Option configures the server runner.
+type Option func(*runner)
+
+// WithServeStdio overrides the function used to serve the MCP server over stdio.
+// This is primarily useful for testing.
+func WithServeStdio(fn func(*server.MCPServer, ...server.StdioOption) error) Option {
+	return func(r *runner) {
+		r.serveStdio = fn
+	}
+}
+
+type runner struct {
+	serveStdio func(*server.MCPServer, ...server.StdioOption) error
+}
+
+// Run starts the MCP server with the given configuration. It blocks until the
+// server exits and returns the exit code (0 for success, 1 for failure).
+//
+// If logger is nil, a default logger is created. If stderr is nil, os.Stderr is used.
+func Run(ctx context.Context, logger *slog.Logger, stderr io.Writer, cfg Config, opts ...Option) int {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if stderr == nil {
+		//nolint:forbidigo // Need a default stderr writer.
+		stderr = os.Stderr
+	}
+
+	r := &runner{
+		serveStdio: server.ServeStdio,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	switch cfg.Transport {
+	case "stdio", "http":
+	default:
+		logger.Error("Unsupported transport", slog.String("transport", cfg.Transport))
+		_, _ = fmt.Fprintf(stderr, "unsupported transport %q (must be \"stdio\" or \"http\")\n", cfg.Transport)
+		return 1
+	}
+
+	logger.Info("Starting k6 MCP server",
+		slog.String("version", buildinfo.Version),
+		slog.String("commit", buildinfo.Commit),
+		slog.String("built_at", buildinfo.Date),
+		slog.Bool("resource_capabilities", true),
+	)
+
+	k6Info, err := k6env.Locate(ctx)
+	if err != nil {
+		return handleK6LookupError(logger, stderr, err)
+	}
+
+	logger.Info("Detected k6 executable", slog.String("path", k6Info.Path))
+
+	finder, err := loadSectionsIndex(logger)
+	if err != nil {
+		logger.Error("Failed to load sections index", slog.String("error", err.Error()))
+		return 1
+	}
+
+	s := createServer(finder)
+
+	if cfg.Transport == "http" {
+		return r.serveHTTP(logger, stderr, s, cfg)
+	}
+
+	logger.Info("Starting MCP server on stdio")
+	if err := r.serveStdio(s); err != nil {
+		logger.Error("Server error", slog.String("error", err.Error()))
+		_, _ = fmt.Fprintf(stderr, "MCP server exited with error: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func (r *runner) serveHTTP(logger *slog.Logger, stderr io.Writer, s *server.MCPServer, cfg Config) int {
+	httpOpts := []server.StreamableHTTPOption{
+		server.WithEndpointPath(cfg.Endpoint),
+	}
+
+	if cfg.Stateless {
+		httpOpts = append(httpOpts, server.WithStateLess(true))
+	}
+
+	httpServer := server.NewStreamableHTTPServer(s, httpOpts...)
+
+	logger.Info("Starting MCP server with Streamable HTTP",
+		slog.String("addr", cfg.Addr),
+		slog.String("endpoint", cfg.Endpoint),
+		slog.Bool("stateless", cfg.Stateless),
+	)
+
+	if err := httpServer.Start(cfg.Addr); err != nil {
+		logger.Error("Server error", slog.String("error", err.Error()))
+		_, _ = fmt.Fprintf(stderr, "MCP server exited with error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func createServer(finder *sections.Finder) *server.MCPServer {
+	s := server.NewMCPServer(
+		"k6",
+		buildinfo.Version,
+		server.WithResourceCapabilities(true, true),
+		server.WithLogging(),
+		server.WithRecovery(),
+		server.WithInstructions(instructions),
+	)
+
+	tools.RegisterInfoTool(s)
+	tools.RegisterValidateTool(s)
+	tools.RegisterRunTool(s)
+	tools.RegisterSearchTerraformTool(s)
+	tools.RegisterListSectionsTool(s, finder)
+	tools.RegisterGetDocumentationTool(s, finder)
+
+	resources.RegisterBestPracticesResource(s)
+	resources.RegisterTypeDefinitionsResources(s)
+
+	prompts.RegisterGenerateScriptPrompt(s)
+	prompts.RegisterConvertPlaywrightScriptPrompt(s)
+
+	return s
+}
+
+func loadSectionsIndex(logger *slog.Logger) (*sections.Finder, error) {
+	logger.Info("Loading sections index")
+	sectionsIdx, err := sections.LoadJSON(k6mcp.SectionsIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load sections index: %w", err)
+	}
+	finder := sections.NewFinder(sectionsIdx)
+
+	totalSections := 0
+	for _, secs := range sectionsIdx.Sections {
+		totalSections += len(secs)
+	}
+	logger.Info("Loaded sections index",
+		slog.Int("version_count", len(sectionsIdx.Versions)),
+		slog.Int("total_sections", totalSections),
+		slog.String("latest_version", sectionsIdx.Latest))
+
+	return finder, nil
+}
+
+func handleK6LookupError(logger *slog.Logger, stderr io.Writer, err error) int {
+	if errors.Is(err, k6env.ErrNotFound) {
+		message := "mcp-k6 requires the `k6` executable on your PATH. Install k6 " +
+			"(https://grafana.com/docs/k6/latest/get-started/installation/) " +
+			"and ensure it is accessible before retrying."
+		logger.Error("k6 executable not found on PATH", slog.String("hint", message))
+		_, _ = fmt.Fprintln(stderr, message)
+		return 1
+	}
+
+	logger.Error("Failed to locate k6 executable", slog.String("error", err.Error()))
+	_, _ = fmt.Fprintf(stderr, "Failed to locate k6 executable: %v\n", err)
+	return 1
+}

--- a/tools/validate.go
+++ b/tools/validate.go
@@ -257,7 +257,7 @@ func executeK6Validation(ctx context.Context, scriptPath string) (*ValidationRes
 	}
 
 	// Prepare k6 command with minimal configuration and additional validation flags
-	cmd := exec.CommandContext(cmdCtx, "k6", "run",
+	cmd := exec.CommandContext(cmdCtx, "k6", "run", // #nosec G204
 		"--vus", "1",
 		"--iterations", "1",
 		"--quiet",
@@ -781,13 +781,14 @@ func addWorkflowIntegrationSuggestions(result *ValidationResponse) {
 	switch {
 	case result.Valid && result.Summary.ReadyToRun:
 		// Script is ready to run - suggest next steps
-		workflowSuggestions := []string{
+		workflowSuggestions := make([]string, 0, 5+len(result.NextSteps))
+		workflowSuggestions = append(workflowSuggestions,
 			"✓ Validation passed! Your script is ready for load testing",
 			"Use the 'run' tool to execute your script with different configurations:",
 			"  • Basic test: {\"vus\": 1, \"duration\": \"30s\"}",
 			"  • Load test: {\"vus\": 10, \"duration\": \"5m\"}",
 			"  • Stress test: {\"vus\": 50, \"duration\": \"10m\"}",
-		}
+		)
 
 		// Insert workflow suggestions at the beginning of next steps
 		result.NextSteps = append(workflowSuggestions, result.NextSteps...)


### PR DESCRIPTION
This pull request refactors the main entrypoint of the `mcp-k6` command-line tool to move the core server logic into a new reusable package, `mcpserver`. The objective being to be able to embed the core logic of the MCP as part of a subcommand extension, so we end up with `k6 x mcp` down the road.

This change enables the MCP server to be used as a library, improves testability, and simplifies the main program.

The main code now delegates configuration parsing and server startup to the `mcpserver` package, and the tests are updated to use the new API.