### PR TITLE
Add official `k6-generate` Claude Code skill

### DIFF
--- a/.claude/skills/k6-generate/SKILL.md
+++ b/.claude/skills/k6-generate/SKILL.md
@@ -24,7 +24,7 @@ If those tools are **not** available, follow the workflow below directly using t
 
 Apply the following best practices:
 
-@resources/best_practices.md
+@best_practices.md
 
 ---
 

--- a/.claude/skills/k6-generate/SKILL.md
+++ b/.claude/skills/k6-generate/SKILL.md
@@ -1,0 +1,49 @@
+---
+description: Generate a production-ready k6 script following official best practices
+argument-hint: describe what you want to test (e.g., "load test my checkout API for 100 users")
+---
+
+Generate a k6 performance test script for: $ARGUMENTS
+
+## Instructions
+
+### Step 1: Check for mcp-k6
+
+If the tools `validate_script`, `run_script`, `list_sections`, and `get_documentation` are available:
+1. Read the `docs://k6/best_practices` resource for current guidelines.
+2. Use `list_sections` + `get_documentation` to look up relevant k6 docs (scenarios, thresholds, the specific protocol you're testing).
+3. Generate the script following the workflow in Step 2 below, informed by what you found in the docs.
+4. Use `validate_script` to verify the script runs cleanly (1 VU, 1 iteration) and fix any errors.
+5. Offer to run with `run_script` and suggest appropriate VU/duration parameters.
+
+If those tools are **not** available, follow the workflow below directly using the embedded best practices.
+
+---
+
+### Step 2: Generate the script
+
+Apply the following best practices:
+
+@resources/best_practices.md
+
+---
+
+### Step 3: Save the script
+
+1. Create the directory `k6/scripts/` if it does not exist.
+2. Choose a descriptive filename in `lowercase-kebab-case.js` (e.g. `checkout-load-test.js`).
+3. Write the complete script to `k6/scripts/<filename>.js`.
+4. Confirm the file path in your response.
+
+---
+
+## Output format
+
+Present your response as:
+
+1. **Script overview** — what the script tests and why the chosen executor/shape fits
+2. **Best practices applied** — 3–5 key decisions made for this specific script
+3. **Generated script** — complete, runnable k6 script with comments
+4. **Script location** — full path where the file was saved
+5. **Validation results** — output from `validate_script` (if mcp-k6 available) or manual checklist
+6. **Next steps** — suggested `run_script` parameters or `k6 run` command with recommended VUs/duration

--- a/README.md
+++ b/README.md
@@ -283,11 +283,13 @@ A `/k6-generate` skill is included in this repo. It wraps the full script-genera
 **Install globally** (works in any project):
 ```bash
 cp -r .claude/skills/k6-generate ~/.claude/skills/
+cp resources/best_practices.md ~/.claude/skills/k6-generate/best_practices.md
 ```
 
 **Install per-project** (checked in with your repo):
 ```bash
 cp -r .claude/skills/k6-generate /path/to/your-project/.claude/skills/
+cp resources/best_practices.md /path/to/your-project/.claude/skills/k6-generate/best_practices.md
 ```
 
 **Usage in Claude Code:**
@@ -298,7 +300,7 @@ cp -r .claude/skills/k6-generate /path/to/your-project/.claude/skills/
 ```
 
 - **With mcp-k6 connected:** uses `list_sections`, `get_documentation`, and `docs://k6/best_practices` for up-to-date context, then validates with `validate_script` and offers `run_script`.
-- **Without mcp-k6:** generates a production-ready script using the best practices from `resources/best_practices.md` and saves it to `k6/scripts/`.
+- **Without mcp-k6:** generates a production-ready script using the best practices bundled in the skill directory (`best_practices.md`) and saves it to `k6/scripts/`.
 
 #### Claude Desktop
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,30 @@ claude mcp add --scope=user --transport=stdio k6 mcp-k6
 
 Use `--scope=local` if you prefer the configuration to live inside the current project. Reload the workspace to pick up the new server.
 
+#### Claude Code Skill (optional)
+
+A `/k6-generate` skill is included in this repo. It wraps the full script-generation workflow into a single discoverable command and degrades gracefully when mcp-k6 is not connected.
+
+**Install globally** (works in any project):
+```bash
+cp -r .claude/skills/k6-generate ~/.claude/skills/
+```
+
+**Install per-project** (checked in with your repo):
+```bash
+cp -r .claude/skills/k6-generate /path/to/your-project/.claude/skills/
+```
+
+**Usage in Claude Code:**
+```
+/k6-generate load test my payments API at 100 concurrent users
+/k6-generate browser test for the checkout flow on example.com
+/k6-generate WebSocket stress test for a chat service
+```
+
+- **With mcp-k6 connected:** uses `list_sections`, `get_documentation`, and `docs://k6/best_practices` for up-to-date context, then validates with `validate_script` and offers `run_script`.
+- **Without mcp-k6:** generates a production-ready script using the best practices from `resources/best_practices.md` and saves it to `k6/scripts/`.
+
 #### Claude Desktop
 
 Place one of the following snippets in your Claude Desktop MCP configuration file (create it if necessary):


### PR DESCRIPTION
Adds a `/k6-generate` Claude Code skill that provides an official, opinionated entry point for AI-assisted k6 script authoring.                                                                                                                                              
                                                                                                                                                                                                                                                                             
Key changes:                                                                                                                                                                                                                                                               
- `.claude/skills/k6-generate/SKILL.md` — skill that uses mcp-k6 tools (validate_script, run_script, docs) when available, and falls back to `resources/best_practices.md` directly when not; single source of truth in both paths                                             
- `README.md` — install instructions under the Claude Code integration section    