### PR TITLE
Expose mcp server functionalities as package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          # xk6 resolves the pinned E2E dependency go.k6.io/k6@v1.7.0,
-          # which requires Go 1.25+.
-          go-version: '1.25.0'
+          go-version-file: 'go.mod'
           cache: false
 
       - name: Test
@@ -64,7 +62,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version-file: 'go.mod'
+          # xk6 resolves the pinned E2E dependency go.k6.io/k6@v1.7.0,
+          # which requires Go 1.25+.
+          go-version: '1.25.0'
           cache: false
 
       - name: Install k6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version-file: 'go.mod'
+          # xk6 resolves the pinned E2E dependency go.k6.io/k6@v1.7.0,
+          # which requires Go 1.25+.
+          go-version: '1.25.0'
           cache: false
 
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo local)
 VERSION ?= dev
 XK6_MCP_VERSION ?= v0.0.3
 XK6_VERSION ?= v1.2.6
+E2E_K6_VERSION ?= v1.7.0
 
 LDFLAGS := -s -w -X github.com/grafana/mcp-k6/internal/buildinfo.Version=$(VERSION) \
 	-X github.com/grafana/mcp-k6/internal/buildinfo.Commit=$(COMMIT) \
@@ -86,6 +87,6 @@ test-e2e: build test-e2e-setup ## Run end-to-end MCP tests
 
 test-e2e-setup: ## Build the xk6-mcp custom k6 binary for e2e tests
 	@command -v xk6 >/dev/null 2>&1 || go install go.k6.io/xk6/cmd/xk6@$(XK6_VERSION)
-	@test -f e2e/k6 || xk6 build --with github.com/dgzlopes/xk6-mcp@$(XK6_MCP_VERSION) --output e2e/k6
+	@test -f e2e/k6 || xk6 build --k6-version $(E2E_K6_VERSION) --with github.com/dgzlopes/xk6-mcp@$(XK6_MCP_VERSION) --output e2e/k6
 
 list: help ## Alias for help


### PR DESCRIPTION
I'm in the process of building support for `k6 x mcp`, via a subcommand extension. This PR moves the core of the logic of the MCP server in a dedicated package we're later able to add as a dependency in the subcommand extension that powers `k6 x mcp`.