### PR TITLE
fix and pin E2E k6 version for xk6 setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version-file: 'go.mod'
+          # xk6 resolves the pinned E2E dependency go.k6.io/k6@v1.7.0,
+          # which requires Go 1.25+.
+          go-version: '1.25.0'
           cache: false
 
       - name: Test
@@ -62,7 +64,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version-file: 'go.mod'
+          # xk6 resolves the pinned E2E dependency go.k6.io/k6@v1.7.0,
+          # which requires Go 1.25+.
+          go-version: '1.25.0'
           cache: false
 
       - name: Install k6

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo local)
 VERSION ?= dev
 XK6_MCP_VERSION ?= v0.0.3
 XK6_VERSION ?= v1.2.6
+E2E_K6_VERSION ?= v1.7.0
 
 LDFLAGS := -s -w -X github.com/grafana/mcp-k6/internal/buildinfo.Version=$(VERSION) \
 	-X github.com/grafana/mcp-k6/internal/buildinfo.Commit=$(COMMIT) \
@@ -86,6 +87,6 @@ test-e2e: build test-e2e-setup ## Run end-to-end MCP tests
 
 test-e2e-setup: ## Build the xk6-mcp custom k6 binary for e2e tests
 	@command -v xk6 >/dev/null 2>&1 || go install go.k6.io/xk6/cmd/xk6@$(XK6_VERSION)
-	@test -f e2e/k6 || xk6 build --with github.com/dgzlopes/xk6-mcp@$(XK6_MCP_VERSION) --output e2e/k6
+	@test -f e2e/k6 || xk6 build --k6-version $(E2E_K6_VERSION) --with github.com/dgzlopes/xk6-mcp@$(XK6_MCP_VERSION) --output e2e/k6
 
 list: help ## Alias for help


### PR DESCRIPTION
This pull request updates the Go version used in CI and the Makefile to ensure compatibility with the `xk6-mcp` dependency for end-to-end (E2E) testing. The main focus is to explicitly set the required Go and k6 versions, ensuring reliable and reproducible builds for E2E tests.

**CI and Build System Updates:**

* Updated the GitHub Actions workflow in `.github/workflows/ci.yml` to use Go version `1.25.0` instead of reading from `go.mod`, addressing a requirement from the `go.k6.io/k6@v1.7.0` dependency used by `xk6`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL47-R49) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL65-R69)

* Added a new `E2E_K6_VERSION` variable in the `Makefile` (defaulting to `v1.7.0`) to standardize the k6 version used for E2E tests.

* Modified the `test-e2e-setup` target in the `Makefile` to use the new `--k6-version $(E2E_K6_VERSION)` flag with `xk6 build`, ensuring the correct k6 version is used when building the custom binary for E2E tests.