### PR TITLE
Fix/trivy base image bump

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,9 +4,11 @@ on:
   workflow_call:
   push:
     branches:
+      - main
       - master
   pull_request:
     branches:
+      - main
       - master
 
 permissions:
@@ -28,3 +30,32 @@ jobs:
 
       - name: Run Go Vulnerability Scanner
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
+
+  image-scan:
+    name: Trivy Image Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          load: true
+          push: false
+          tags: mcp-k6:ci-scan
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
+        with:
+          image-ref: mcp-k6:ci-scan
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          format: table

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN make build
 
 # Final stage
-FROM grafana/k6:latest-with-browser@sha256:6739361fcfc03c44032b345a9e280c4af3222e75d9e29effd09a223791b90a84
+FROM grafana/k6:latest-with-browser@sha256:f07f174bdf5852b3819e55edd0ef0906d3d32d285d4b4750fc763d70a83ee80e
 
 LABEL io.modelcontextprotocol.server.name="io.github.grafana/mcp-k6"
 


### PR DESCRIPTION
This pull request enhances the security workflow and updates the Docker image used in the project. The main changes are the addition of an automated container image vulnerability scan to the GitHub Actions workflow and updating the base image in the `Dockerfile` to a newer version.

**Security workflow improvements:**

* Added a new `image-scan` job to `.github/workflows/security.yml` that builds the Docker image and scans it for vulnerabilities using Trivy, focusing on HIGH and CRITICAL severity issues.
* Updated the workflow triggers to include the `main` branch alongside `master` for both `push` and `pull_request` events, ensuring security checks run on all primary branches.

**Docker image update:**

* Changed the base image in the `Dockerfile` to a newer `grafana/k6:latest-with-browser` version, updating the referenced image digest for improved security and stability.

closes #70 
closes #65 