### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# by default the k6-core team is the owner of all files
+* @ankur22
+* @inancgumus
+* @vortegatorres
+* @andrewslotin


### PR DESCRIPTION
This pull request updates the `CODEOWNERS` file to set default code ownership for the repository.

Ownership assignment:

* All files are now owned by the `k6-core` team, specifically assigning `@ankur22`, `@inancgumus`, `@vortegatorres`, and `@andrewslotin` as code owners.