### PR TITLE
Make dangerous pattern matching case-sensitive

### DIFF
--- a/e2e/tools_test.js
+++ b/e2e/tools_test.js
@@ -103,11 +103,10 @@ function testValidateScriptTool(client) {
 }
 
 function testRunScriptTool(client) {
-  // Note: space before () avoids security pattern match on "Function(" / "function("
   const result = client.callTool({
     name: "run_script",
     arguments: {
-      script: "export default function () {}",
+      script: "export default function() {}",
       iterations: 1,
     },
   });
@@ -120,7 +119,6 @@ function testRunScriptTool(client) {
 }
 
 function testRunScriptToolPreservesScriptScenarios(client) {
-  // Note: space before () avoids security pattern match on "Function(" / "function("
   const result = client.callTool({
     name: "run_script",
     arguments: {
@@ -135,7 +133,7 @@ export const options = {
   },
 };
 
-export default function () {}
+export default function() {}
 `,
     },
   });

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -291,10 +291,8 @@ func dangerousPatternCatalog() map[string]PatternInfo {
 
 // checkDangerousPatternsWithSuggestions scans for dangerous patterns and provides corrections
 func checkDangerousPatternsWithSuggestions(ctx context.Context, content string) error {
-	contentLower := strings.ToLower(content)
-
 	for pattern, info := range dangerousPatternCatalog() {
-		if strings.Contains(contentLower, strings.ToLower(pattern)) {
+		if strings.Contains(content, pattern) {
 			err := &Error{
 				Type: "DANGEROUS_PATTERN",
 				Message: fmt.Sprintf(

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -1,0 +1,119 @@
+package security
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestValidateScriptContentAllowsStaticFunctionDefinitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{
+			name: "default function without space before parens",
+			script: `import http from "k6/http";
+
+export default function() {
+  http.get("https://example.com");
+}`,
+		},
+		{
+			name: "async default function",
+			script: `export default async function() {
+}`,
+		},
+		{
+			name: "callback function",
+			script: `import { group } from "k6";
+
+export default function() {
+  group("browse", function() {
+  });
+}`,
+		},
+		{
+			name: "shared array initializer function",
+			script: `import { SharedArray } from "k6/data";
+
+const users = new SharedArray("users", function() {
+  return [];
+});
+
+export default function() {
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := ValidateScriptContent(context.Background(), tt.script); err != nil {
+				t.Fatalf("ValidateScriptContent() returned unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateScriptContentRejectsDangerousPatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{
+			name: "function constructor",
+			script: `export default function() {
+  Function("return 1")();
+}`,
+		},
+		{
+			name: "new function constructor",
+			script: `export default function() {
+  new Function("return 1")();
+}`,
+		},
+		{
+			name: "eval",
+			script: `export default function() {
+  eval("1 + 1");
+}`,
+		},
+		{
+			name: "dynamic import",
+			script: `export default function() {
+  import("k6/http");
+}`,
+		},
+		{
+			name: "child process require",
+			script: `export default function() {
+  require("child_process");
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateScriptContent(context.Background(), tt.script)
+			if err == nil {
+				t.Fatal("ValidateScriptContent() returned nil error")
+			}
+
+			var securityErr *Error
+			if !errors.As(err, &securityErr) {
+				t.Fatalf("ValidateScriptContent() error type = %T, want *Error", err)
+			}
+			if securityErr.Type != "DANGEROUS_PATTERN" {
+				t.Fatalf("ValidateScriptContent() error type = %q, want DANGEROUS_PATTERN", securityErr.Type)
+			}
+		})
+	}
+}

--- a/tools/run_test.go
+++ b/tools/run_test.go
@@ -72,7 +72,7 @@ func TestBuildK6Args(t *testing.T) {
 	}
 }
 
-const emptyDefaultExportScript = "export default function () {}"
+const emptyDefaultExportScript = "export default function() {}"
 
 func TestParseRunOptions(t *testing.T) {
 	t.Parallel()
@@ -267,6 +267,6 @@ func scenarioScript() string {
   },
 };
 
-export default function () {}
-`
+export default function() {}
+	`
 }


### PR DESCRIPTION
This pull request improves the security pattern detection logic and strengthens test coverage for script validation. The main change is to make the pattern-matching logic case-sensitive, which prevents false positives for allowed static function definitions, and to add comprehensive tests for both allowed and disallowed script patterns.

**Security pattern matching improvements:**

* The dangerous pattern detection in `checkDangerousPatternsWithSuggestions` is now case-sensitive, avoiding unnecessary false positives for legitimate static function definitions. (`internal/security/security.go`)

**Test coverage enhancements:**

* Added a new test suite in `security_test.go` to verify that static function definitions (including async functions, callbacks, and shared array initializers) are allowed and not incorrectly flagged as dangerous. (`internal/security/security_test.go`)
* Introduced tests to ensure that truly dangerous patterns (such as use of `Function`, `eval`, dynamic `import`, and `require('child_process')`) are correctly detected and rejected. (`internal/security/security_test.go`)

**Code cleanup:**

* Removed outdated security pattern workaround comments in `tools_test.js` now that the pattern matching is more precise. (`e2e/tools_test.js`) [[1]](diffhunk://#diff-af4c1f56c627ad4fc89733f1dae108c11448d0dbdb997d85582424bc66070c86L106) [[2]](diffhunk://#diff-af4c1f56c627ad4fc89733f1dae108c11448d0dbdb997d85582424bc66070c86L123)



fixes #85 