### PR TITLE
test(tools): snapshot tool JSON schemas to lock the MCP contract

### DIFF
--- a/tools/testdata/toolsnaps/get_documentation.json
+++ b/tools/testdata/toolsnaps/get_documentation.json
@@ -1,0 +1,26 @@
+{
+  "annotations": {
+    "destructiveHint": true,
+    "idempotentHint": false,
+    "openWorldHint": true,
+    "readOnlyHint": false
+  },
+  "description": "Retrieves the full markdown content of a specific k6 documentation section. Use the slug from list_sections output (e.g., 'using-k6/scenarios', 'javascript-api/k6-http/request'). Returns the complete markdown content with frontmatter metadata. Supports multiple k6 versions - specify version parameter or defaults to latest. Use this when you need detailed documentation for a specific topic.",
+  "inputSchema": {
+    "properties": {
+      "slug": {
+        "description": "Section slug to retrieve (e.g., 'using-k6/scenarios', 'javascript-api/k6-http'). Get valid slugs from list_sections tool. Supports aliases.",
+        "type": "string"
+      },
+      "version": {
+        "description": "Optional: k6 version (e.g., 'v1.4.x', 'v0.57.x'). Defaults to latest. Use list_sections with version='all' to see available versions.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "slug"
+    ],
+    "type": "object"
+  },
+  "name": "get_documentation"
+}

--- a/tools/testdata/toolsnaps/info.json
+++ b/tools/testdata/toolsnaps/info.json
@@ -1,0 +1,15 @@
+{
+  "annotations": {
+    "destructiveHint": true,
+    "idempotentHint": false,
+    "openWorldHint": true,
+    "readOnlyHint": false
+  },
+  "description": "Get details about the mcp-k6 server, the local k6 binary, and k6 Cloud login status.",
+  "inputSchema": {
+    "properties": {},
+    "required": [],
+    "type": "object"
+  },
+  "name": "info"
+}

--- a/tools/testdata/toolsnaps/list_sections.json
+++ b/tools/testdata/toolsnaps/list_sections.json
@@ -1,0 +1,32 @@
+{
+  "annotations": {
+    "destructiveHint": true,
+    "idempotentHint": false,
+    "openWorldHint": true,
+    "readOnlyHint": false
+  },
+  "description": "Lists k6 documentation sections in a hierarchical tree structure. Use this to understand documentation organization and discover related topics. Navigate progressively: start at root, then use root_slug to expand branches. Returns compact metadata (no content) to minimize context usage. Use get_documentation to retrieve the full content for a specific section.",
+  "inputSchema": {
+    "properties": {
+      "category": {
+        "description": "Optional: Filter by top-level category (e.g., 'using-k6', 'javascript-api'). Use without this parameter to see all categories.",
+        "type": "string"
+      },
+      "depth": {
+        "description": "Optional: Depth of hierarchy to return (default: 1, max: 5). Depth counts how many levels of children are included in the tree.",
+        "type": "number"
+      },
+      "root_slug": {
+        "description": "Optional: List the contents under this slug (i.e., its children). Use the slug from a previous list_sections response.",
+        "type": "string"
+      },
+      "version": {
+        "description": "Optional: k6 version to list sections for (e.g., 'v1.4.x', 'v0.57.x'). Defaults to latest version. Use 'all' to see available versions.",
+        "type": "string"
+      }
+    },
+    "required": [],
+    "type": "object"
+  },
+  "name": "list_sections"
+}

--- a/tools/testdata/toolsnaps/run_script.json
+++ b/tools/testdata/toolsnaps/run_script.json
@@ -1,0 +1,34 @@
+{
+  "annotations": {
+    "destructiveHint": true,
+    "idempotentHint": false,
+    "openWorldHint": true,
+    "readOnlyHint": false
+  },
+  "description": "Run a k6 test script with configurable parameters. Returns execution results including stdout, stderr, exit code, and raw metrics from k6.",
+  "inputSchema": {
+    "properties": {
+      "duration": {
+        "description": "Test duration (max: '5m'). When omitted, script-defined options and k6 defaults are used. Examples: '30s', '2m', '5m'. Overridden by iterations if specified.",
+        "type": "string"
+      },
+      "iterations": {
+        "description": "Number of iterations per VU (overrides duration). Examples: 1 for single run, 100 for throughput test.",
+        "type": "number"
+      },
+      "script": {
+        "description": "The k6 script content to run (JavaScript/TypeScript). Should be a valid k6 script with proper imports and default function.",
+        "type": "string"
+      },
+      "vus": {
+        "description": "Number of virtual users. When omitted, script-defined options and k6 defaults are used. Examples: 1 for basic test, 10 for moderate load, 100 for stress test.",
+        "type": "number"
+      }
+    },
+    "required": [
+      "script"
+    ],
+    "type": "object"
+  },
+  "name": "run_script"
+}

--- a/tools/testdata/toolsnaps/search_terraform.json
+++ b/tools/testdata/toolsnaps/search_terraform.json
@@ -1,0 +1,26 @@
+{
+  "annotations": {
+    "destructiveHint": true,
+    "idempotentHint": false,
+    "openWorldHint": true,
+    "readOnlyHint": false
+  },
+  "description": "Search for k6 Cloud-related resources in the Grafana Terraform provider. Queries the installed provider schema and filters resources by name.",
+  "inputSchema": {
+    "properties": {
+      "root": {
+        "default": ".",
+        "description": "Root directory of the Terraform project (default: current directory).",
+        "type": "string"
+      },
+      "term": {
+        "default": "k6",
+        "description": "Search term to filter resources by name (default: 'k6'). Case-insensitive.",
+        "type": "string"
+      }
+    },
+    "required": [],
+    "type": "object"
+  },
+  "name": "search_terraform"
+}

--- a/tools/testdata/toolsnaps/validate_script.json
+++ b/tools/testdata/toolsnaps/validate_script.json
@@ -1,0 +1,22 @@
+{
+  "annotations": {
+    "destructiveHint": true,
+    "idempotentHint": false,
+    "openWorldHint": true,
+    "readOnlyHint": false
+  },
+  "description": "Validate a k6 script by running it with minimal configuration (1 VU, 1 iteration). Returns detailed validation results with syntax errors, runtime issues, and actionable recommendations for fixing problems.",
+  "inputSchema": {
+    "properties": {
+      "script": {
+        "description": "The k6 script content to validate (either JavaScript or TypeScript code). Example: 'import http from \"k6/http\"; export default function() { http.get(\"https://httpbin.org/get\"); }'",
+        "type": "string"
+      }
+    },
+    "required": [
+      "script"
+    ],
+    "type": "object"
+  },
+  "name": "validate_script"
+}

--- a/tools/toolsnaps_test.go
+++ b/tools/toolsnaps_test.go
@@ -1,0 +1,89 @@
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// snapshotTools returns every tool the server registers (see
+// mcpserver/server.go), so the snapshot guard covers the full MCP tool contract.
+// Keep this list in sync with the registrations in mcpserver.
+func snapshotTools() []mcp.Tool {
+	return []mcp.Tool{
+		InfoTool,
+		ValidateTool,
+		RunTool,
+		SearchTerraformTool,
+		ListSectionsTool,
+		GetDocumentationTool,
+	}
+}
+
+// TestToolSchemaSnapshots locks each tool's serialized JSON schema against a
+// committed golden file. Any change to a tool's name, description, input schema,
+// or annotations changes what clients and LLMs see, so it must be an intentional,
+// reviewable diff. Regenerate the goldens after an intended change with:
+//
+//	UPDATE_TOOLSNAPS=true go test ./tools/ -run TestToolSchemaSnapshots
+func TestToolSchemaSnapshots(t *testing.T) {
+	t.Parallel()
+
+	update := os.Getenv("UPDATE_TOOLSNAPS") != ""
+
+	for _, tool := range snapshotTools() {
+		t.Run(tool.Name, func(t *testing.T) {
+			t.Parallel()
+
+			got := canonicalToolSchema(t, tool)
+			golden := filepath.Join("testdata", "toolsnaps", tool.Name+".json")
+
+			if update {
+				writeGolden(t, golden, got)
+				return
+			}
+
+			//nolint:forbidigo // Test reads a committed golden file under testdata.
+			want, err := os.ReadFile(golden)
+			require.NoErrorf(t, err,
+				"missing snapshot for tool %q; regenerate with UPDATE_TOOLSNAPS=true go test ./tools/ -run TestToolSchemaSnapshots",
+				tool.Name)
+
+			require.Equalf(t, string(want), string(got),
+				"tool %q schema changed; if intentional, regenerate with UPDATE_TOOLSNAPS=true go test ./tools/ -run TestToolSchemaSnapshots",
+				tool.Name)
+		})
+	}
+}
+
+// canonicalToolSchema marshals a tool to a stable, indented JSON form so goldens
+// are deterministic and produce readable diffs. Round-tripping through a generic
+// value sorts map keys (encoding/json orders object keys), which keeps the
+// output independent of map iteration order.
+func canonicalToolSchema(t *testing.T, tool mcp.Tool) string {
+	t.Helper()
+
+	raw, err := json.Marshal(tool)
+	require.NoErrorf(t, err, "marshal tool %q", tool.Name)
+
+	var generic any
+	require.NoErrorf(t, json.Unmarshal(raw, &generic), "unmarshal tool %q", tool.Name)
+
+	canonical, err := json.MarshalIndent(generic, "", "  ")
+	require.NoErrorf(t, err, "re-marshal tool %q", tool.Name)
+
+	return string(canonical) + "\n"
+}
+
+func writeGolden(t *testing.T, path, content string) {
+	t.Helper()
+
+	//nolint:forbidigo // Test helper creates the testdata snapshot directory.
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	//nolint:forbidigo // Test helper writes a committed golden file under testdata.
+	require.NoErrorf(t, os.WriteFile(path, []byte(content), 0o600), "write snapshot %q", path)
+}


### PR DESCRIPTION
## What

Add `TestToolSchemaSnapshots`: a snapshot test that locks every registered tool's
serialized JSON schema against a committed golden file under
`tools/testdata/toolsnaps/`.

Refs #149.

## Why

The six tools (`info`, `validate_script`, `run_script`, `search_terraform`,
`list_sections`, `get_documentation`) are defined with hand-written
`mcp.NewTool(...)` builders and nothing guards their wire-level schema. A careless
edit to a description or a parameter definition silently changes what every client
and LLM sees. This test turns that into a reviewable diff.

Approach mirrors `github/github-mcp-server`'s `internal/toolsnaps`.

## How it works

- Each tool is marshaled to canonical, indented JSON (round-tripped through a
  generic value so object keys are ordered deterministically) and compared to
  `tools/testdata/toolsnaps/<name>.json`.
- On an intentional change, regenerate the goldens:
  ```
  UPDATE_TOOLSNAPS=true go test ./tools/ -run TestToolSchemaSnapshots
  ```
- Runs under the existing `make test` / CI `test` job. No new dependencies.

## Notes

The committed goldens capture the current schemas as-is, including the default tool
annotations mcp-go emits (e.g. `info` currently serializes `readOnlyHint: false`).
That is intentional for this PR — it snapshots today's contract. Correcting those
annotations belongs to the structured-output migration (#150), where the snapshot
diff will make each change explicit and reviewable.

## Tests

`go test ./...`, `go vet ./...`, `gofmt -l` all clean. Verified the test passes in
check mode and fails with a clear diff when a schema is altered.
