### PR TITLE
fix(k6env): treat logged-out k6 Cloud state as not-an-error

### DIFF
--- a/internal/k6env/login.go
+++ b/internal/k6env/login.go
@@ -22,13 +22,30 @@ func (i Info) IsLoggedIn(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to check k6 cloud login status: %w", err)
 	}
 
-	raw := strings.TrimSpace(string(output))
+	return parseCloudLoginStatus(string(output))
+}
 
-	re := regexp.MustCompile(`(?m)^\s*token:\s*([0-9a-fA-F]{64})\s*$`)
-	if !re.MatchString(raw) {
-		return false, fmt.Errorf("unable to determine k6 cloud login status: unexpected output format")
+// tokenLineRE captures the value of the "token:" line printed by
+// `k6 cloud login --show` (e.g. "  token: <not set>" or "  token: <value>").
+var tokenLineRE = regexp.MustCompile(`(?m)^\s*token:\s*(.*?)\s*$`)
+
+// parseCloudLoginStatus interprets the output of `k6 cloud login --show`.
+//
+// Being logged out is a valid state, not an error: k6 prints "token: <not set>"
+// (and exits 0) when no token is stored. Only genuinely unrecognizable output
+// (no token line at all) is treated as an error.
+func parseCloudLoginStatus(output string) (bool, error) {
+	raw := strings.TrimSpace(output)
+
+	match := tokenLineRE.FindStringSubmatch(raw)
+	if match == nil {
+		return false, errors.New("unable to determine k6 cloud login status: unexpected output format")
 	}
-	token := re.FindStringSubmatch(raw)[1]
 
-	return token != "", nil
+	token := strings.TrimSpace(match[1])
+	if token == "" || token == "<not set>" {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/internal/k6env/login_test.go
+++ b/internal/k6env/login_test.go
@@ -1,0 +1,59 @@
+package k6env
+
+import "testing"
+
+func TestParseCloudLoginStatus(t *testing.T) {
+	t.Parallel()
+
+	// notSetOutput mirrors `k6 cloud login --show` for a logged-out user on
+	// k6 v2.x: a banner followed by placeholder fields.
+	const notSetOutput = `
+         /\      Grafana   /‾‾/
+    /\  /  \     |\  __   /  /
+   /  \/    \    | |/ /  /   ‾‾\
+
+  token: <not set>
+  stack-id: <not set>
+  stack-url: <not set>
+  default-project-id: <not set>
+`
+
+	const loggedInOutput = `
+  token: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  stack-id: 12345
+`
+
+	tests := []struct {
+		name       string
+		output     string
+		wantLogged bool
+		wantErr    bool
+	}{
+		{name: "logged out shows not set", output: notSetOutput, wantLogged: false},
+		{name: "logged in shows token", output: loggedInOutput, wantLogged: true},
+		{name: "token value present but non-hex is still logged in", output: "  token: abc-masked-value", wantLogged: true},
+		{name: "empty token value is logged out", output: "  token: ", wantLogged: false},
+		{name: "no token line is an error", output: "  stack-id: <not set>", wantErr: true},
+		{name: "empty output is an error", output: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logged, err := parseCloudLoginStatus(tt.output)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseCloudLoginStatus(%q) = (%v, nil), want error", tt.output, logged)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCloudLoginStatus(%q) returned unexpected error: %v", tt.output, err)
+			}
+			if logged != tt.wantLogged {
+				t.Fatalf("parseCloudLoginStatus(%q) = %v, want %v", tt.output, logged, tt.wantLogged)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fix the `info` tool failing whenever the user is not logged in to k6 Cloud.

Fixes #153.

## Root cause

`Info.IsLoggedIn` (`internal/k6env/login.go`) ran `k6 cloud login --show` and
required the output to match a strict 64-hex-character token regex, returning an
**error** on any mismatch. When logged out, k6 prints `token: <not set>` and exits 0,
so the regex failed and the error propagated up, making the whole `info` tool return
`isError: true` instead of a normal response with `logged_in: false`.

## Change

- Extract parsing into a pure `parseCloudLoginStatus` function.
- Interpret the `token:` line: `<not set>` or empty -> `logged_in = false` (no error);
  any other value -> `logged_in = true`; only a genuinely missing `token:` line is
  treated as unexpected output. This is also more robust across k6 versions than the
  exact 64-hex match.
- Add `parseCloudLoginStatus` unit tests (logged-out banner, logged-in token,
  masked value, empty value, missing line, empty output).

## Verification

Driven end-to-end over MCP stdio against k6 v2.0.0 (logged out):

Before: `info` returned `isError: true` — "unable to determine k6 cloud login
status: unexpected output format".

After:
```
isError: (none)
{"version":"dev","k6_version":"2.0.0","logged_in":false}
```

`go test ./...`, `go vet ./...`, `gofmt -l` all clean.
