### PR TITLE
feat(tools): return a structured end-of-test summary from run_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,13 @@ Parameters:
 - `duration` (string, optional): Duration override, max `5m`. When omitted, script-defined options and k6 defaults are used.
 - `iterations` (number, optional): Iterations override. When provided with a positive value, it takes precedence over `duration`.
 
-Returns: `success`, `exit_code`, `stdout`, `stderr`, `error`, `duration`, `metrics`, `summary`
+Returns: `success`, `exit_code`, `exit_reason`, `thresholds_failed`, `stdout`, `stderr`, `error`, `warnings`, `duration`, `summary`, `next_steps`
+
+Response highlights:
+- `summary`: Structured end-of-test results captured via `--summary-export`. Contains `metrics` (each with an inferred `type` and the raw k6 `values` such as `avg`, `p(95)`, `count`, `rate`), `thresholds` (one entry per expression with `metric`, `expression`, `passed`) and `checks` (`passes`, `fails`).
+- `thresholds_failed` and `exit_reason`: k6 exits non-zero when a threshold is crossed, so `success` is `false` while `thresholds_failed` is `true` and `summary` is fully populated. `exit_reason` maps known k6 exit codes to labels such as `thresholds_failed`, `script_exception` or `setup_timeout`; unrecognised codes report `unknown`.
+- `stdout`: Truncated to a 4 KiB preview once `summary` is available. `stderr` is never truncated.
+- `warnings`: Set when the summary could not be captured, for example when k6 aborted before the end of the test.
 
 ### list_sections
 

--- a/e2e/tools_test.js
+++ b/e2e/tools_test.js
@@ -14,6 +14,7 @@ export default function () {
   testGetDocumentationTool(client);
   testValidateScriptTool(client);
   testRunScriptTool(client);
+  testRunScriptToolReportsThresholdFailure(client);
   testSearchTerraformTool(client);
 }
 
@@ -116,6 +117,47 @@ function testRunScriptTool(client) {
   expect(data).toHaveProperty("success");
   expect(data).toHaveProperty("exit_code");
   expect(data.success).toBe(true);
+  expect(data.exit_reason).toBe("success");
+  expect(data.thresholds_failed).toBe(false);
+  expect(data).toHaveProperty("summary");
+  expect(data.summary.metrics).toHaveProperty("iterations");
+}
+
+function testRunScriptToolReportsThresholdFailure(client) {
+  const result = client.callTool({
+    name: "run_script",
+    arguments: {
+      script: `
+import { check } from 'k6';
+
+export const options = {
+  thresholds: {
+    checks: ['rate>0.5'],
+    iterations: ['count>=1'],
+  },
+};
+
+export default function() {
+  check(false, { 'always fails': (v) => v });
+}
+`,
+      iterations: 1,
+    },
+  });
+  expect(result.content.length).toBeGreaterThan(0);
+
+  const data = JSON.parse(result.content[0].text);
+  expect(data.success).toBe(false);
+  expect(data.thresholds_failed).toBe(true);
+  expect(data.exit_reason).toBe("thresholds_failed");
+  expect(data).toHaveProperty("summary");
+  expect(data.summary.checks.fails).toBe(1);
+
+  const thresholds = Object.fromEntries(
+    data.summary.thresholds.map((t) => [`${t.metric}:${t.expression}`, t.passed]),
+  );
+  expect(thresholds["checks:rate>0.5"]).toBe(false);
+  expect(thresholds["iterations:count>=1"]).toBe(true);
 }
 
 function testRunScriptToolPreservesScriptScenarios(client) {

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -15,12 +15,15 @@ import (
 const (
 	// DefaultTimeout is the default timeout for k6 operations.
 	DefaultTimeout = 5 * time.Minute
+
+	scriptTempFilePattern  = "k6-run-*.js"
+	summaryTempFilePattern = "k6-summary-*.json"
 )
 
-// createSecureTempFile creates a secure temporary file with the script content.
-func createSecureTempFile(script string) (string, func(), error) {
+// createSecureTempFile creates a secure temporary file matching pattern with the given content.
+func createSecureTempFile(pattern, content string) (string, func(), error) {
 	//nolint:forbidigo // Temporary file creation required for k6 execution
-	tmpFile, err := os.CreateTemp("", "k6-run-*.js")
+	tmpFile, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create temporary file: %w", err)
 	}
@@ -36,7 +39,7 @@ func createSecureTempFile(script string) (string, func(), error) {
 		}
 	}
 
-	if err := setupTempFile(tmpFile, script); err != nil {
+	if err := setupTempFile(tmpFile, content); err != nil {
 		cleanupTempFile(tmpFile)
 		return "", nil, err
 	}
@@ -47,16 +50,15 @@ func createSecureTempFile(script string) (string, func(), error) {
 // setupTempFile configures and writes to the temporary file.
 //
 //nolint:forbidigo // Function parameter os.File required for temp file operations
-func setupTempFile(tmpFile *os.File, script string) error {
+func setupTempFile(tmpFile *os.File, content string) error {
 	// Set secure permissions (owner read/write only)
 	const secureFileMode = 0o600
 	if err := tmpFile.Chmod(secureFileMode); err != nil {
 		return fmt.Errorf("failed to set secure file permissions: %w", err)
 	}
 
-	// Write script content
-	if _, err := tmpFile.WriteString(script); err != nil {
-		return fmt.Errorf("failed to write script to temporary file: %w", err)
+	if _, err := tmpFile.WriteString(content); err != nil {
+		return fmt.Errorf("failed to write to temporary file: %w", err)
 	}
 
 	if err := tmpFile.Close(); err != nil {

--- a/tools/run.go
+++ b/tools/run.go
@@ -7,16 +7,20 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/grafana/mcp-k6/internal/helpers"
 	"github.com/grafana/mcp-k6/internal/logging"
 	"github.com/grafana/mcp-k6/internal/security"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/lib/types"
 	"gopkg.in/guregu/null.v3"
 )
@@ -28,7 +32,8 @@ var RunTool = mcp.NewTool(
 	"run_script",
 	mcp.WithDescription(
 		"Run a k6 test script with configurable parameters. "+
-			"Returns execution results including stdout, stderr, exit code, and raw metrics from k6.",
+			"Returns execution results including exit code, exit reason, a structured end-of-test summary "+
+			"(metrics, thresholds, checks), and a bounded stdout preview.",
 	),
 	mcp.WithString(
 		"script",
@@ -95,6 +100,9 @@ func run(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult,
 const (
 	// MaxDuration is the maximum test duration allowed.
 	MaxDuration = 5 * time.Minute
+
+	// MaxStdoutPreviewBytes caps stdout once the structured summary is available.
+	MaxStdoutPreviewBytes = 4 * 1024
 )
 
 // RunOptions contains configuration options for running k6 tests.
@@ -242,14 +250,43 @@ func parseOptionalDurationArg(args map[string]any, name string) (types.NullDurat
 
 // RunResult contains the result of a k6 test execution.
 type RunResult struct {
-	Success   bool                   `json:"success"`
-	ExitCode  int                    `json:"exit_code"`
-	Stdout    string                 `json:"stdout"`
-	Stderr    string                 `json:"stderr"`
-	Error     string                 `json:"error,omitempty"`
-	Duration  string                 `json:"duration"`
-	Metrics   map[string]interface{} `json:"metrics,omitempty"`
-	NextSteps []string               `json:"next_steps,omitempty"`
+	Success          bool        `json:"success"`
+	ExitCode         int         `json:"exit_code"`
+	ExitReason       string      `json:"exit_reason,omitempty"`
+	ThresholdsFailed bool        `json:"thresholds_failed"`
+	Stdout           string      `json:"stdout"`
+	Stderr           string      `json:"stderr"`
+	Error            string      `json:"error,omitempty"`
+	Warnings         []string    `json:"warnings,omitempty"`
+	Duration         string      `json:"duration"`
+	Summary          *RunSummary `json:"summary,omitempty"`
+	NextSteps        []string    `json:"next_steps,omitempty"`
+}
+
+// RunSummary is the structured end-of-test summary exported by k6.
+type RunSummary struct {
+	Metrics    map[string]MetricSummary `json:"metrics"`
+	Thresholds []ThresholdResult        `json:"thresholds,omitempty"`
+	Checks     *CheckSummary            `json:"checks,omitempty"`
+}
+
+// MetricSummary holds the aggregated values k6 reported for a single metric.
+type MetricSummary struct {
+	Type   string             `json:"type,omitempty"`
+	Values map[string]float64 `json:"values"`
+}
+
+// ThresholdResult reports whether a single threshold expression passed.
+type ThresholdResult struct {
+	Metric     string `json:"metric"`
+	Expression string `json:"expression"`
+	Passed     bool   `json:"passed"`
+}
+
+// CheckSummary aggregates check outcomes across the whole run.
+type CheckSummary struct {
+	Passes int `json:"passes"`
+	Fails  int `json:"fails"`
 }
 
 // RunError represents errors that occur during k6 test execution.
@@ -296,7 +333,7 @@ func RunK6Test(ctx context.Context, script string, options *RunOptions) (*RunRes
 	logger.DebugContext(ctx, "Test input validation passed")
 
 	// Create secure temporary file
-	tempFile, cleanup, err := createSecureTempFile(script)
+	tempFile, cleanup, err := createSecureTempFile(scriptTempFilePattern, script)
 	if err != nil {
 		logging.FileOperation(ctx, "runner", "create_temp_file", tempFile, err)
 		return &RunResult{
@@ -309,11 +346,24 @@ func RunK6Test(ctx context.Context, script string, options *RunOptions) (*RunRes
 
 	logging.FileOperation(ctx, "runner", "create_temp_file", tempFile, nil)
 
+	summaryFile, cleanupSummary, err := createSecureTempFile(summaryTempFilePattern, "")
+	if err != nil {
+		logging.FileOperation(ctx, "runner", "create_summary_file", summaryFile, err)
+		return &RunResult{
+			Success:  false,
+			Error:    fmt.Sprintf("failed to create summary file: %v", err),
+			Duration: time.Since(startTime).String(),
+		}, err
+	}
+	defer cleanupSummary()
+
+	logging.FileOperation(ctx, "runner", "create_summary_file", summaryFile, nil)
+
 	// Execute k6 test
 	logger.DebugContext(ctx, "Starting k6 test execution",
 		slog.String("script_path", helpers.GetPathType(tempFile)),
 		slog.Any("options", sanitizeRunOptions(options)))
-	result, err := executeK6Test(ctx, tempFile, options)
+	result, err := executeK6Test(ctx, tempFile, summaryFile, options)
 	if err != nil {
 		return nil, fmt.Errorf("executing k6 script failed; reason: %w", err)
 	}
@@ -414,7 +464,7 @@ func validateDuration(options *RunOptions) error {
 // executeK6Test executes k6 with the given script file and options.
 //
 //nolint:funlen // Function length slightly exceeds limit due to comprehensive logging
-func executeK6Test(ctx context.Context, scriptPath string, options *RunOptions) (*RunResult, error) {
+func executeK6Test(ctx context.Context, scriptPath, summaryPath string, options *RunOptions) (*RunResult, error) {
 	logger := logging.LoggerFromContext(ctx)
 	startTime := time.Now()
 
@@ -439,7 +489,7 @@ func executeK6Test(ctx context.Context, scriptPath string, options *RunOptions) 
 	logger.DebugContext(ctx, "Environment validation passed")
 
 	// Build k6 command arguments
-	args := buildK6Args(scriptPath, options)
+	args := buildK6Args(scriptPath, summaryPath, options)
 
 	logger.DebugContext(ctx, "Executing k6 test command",
 		slog.Any("args", args),
@@ -464,19 +514,15 @@ func executeK6Test(ctx context.Context, scriptPath string, options *RunOptions) 
 	stderr = security.SanitizeOutput(stderr)
 
 	result := &RunResult{
-		Success:  exitCode == 0,
-		ExitCode: exitCode,
-		Stdout:   stdout,
-		Stderr:   stderr,
+		Success:          exitCode == 0,
+		ExitCode:         exitCode,
+		ExitReason:       exitReason(exitCode),
+		ThresholdsFailed: exitCode == int(exitcodes.ThresholdsHaveFailed),
+		Stdout:           stdout,
+		Stderr:           stderr,
 	}
 
-	// Parse metrics from output
-	if result.Success {
-		logger.DebugContext(ctx, "Parsing k6 output for metrics")
-		result.Metrics = parseK6Output(stdout)
-		logger.DebugContext(ctx, "Metrics parsed",
-			slog.Int("metric_count", len(result.Metrics)))
-	}
+	attachSummary(ctx, result, summaryPath)
 
 	// Handle different types of errors
 	if err != nil {
@@ -521,8 +567,8 @@ func executeK6Test(ctx context.Context, scriptPath string, options *RunOptions) 
 }
 
 // buildK6Args builds the command line arguments for k6 based on the provided options.
-func buildK6Args(scriptPath string, options *RunOptions) []string {
-	args := []string{"run"}
+func buildK6Args(scriptPath, summaryPath string, options *RunOptions) []string {
+	args := []string{"run", "--summary-export=" + summaryPath}
 
 	if options != nil {
 		if options.VUs.Valid && options.VUs.Int64 > 0 {
@@ -542,34 +588,176 @@ func buildK6Args(scriptPath string, options *RunOptions) []string {
 	return args
 }
 
-// parseK6Output parses k6 output to extract raw metrics.
-func parseK6Output(output string) map[string]interface{} {
-	metrics := make(map[string]interface{})
+func attachSummary(ctx context.Context, result *RunResult, summaryPath string) {
+	logger := logging.LoggerFromContext(ctx)
 
-	// Split output into lines and parse JSON metrics
-	lines := strings.Split(output, "\n")
-	var jsonMetrics []map[string]interface{}
+	summary, err := readSummaryExport(summaryPath)
+	if err != nil {
+		logger.WarnContext(ctx, "k6 summary export unavailable",
+			slog.String("error", err.Error()))
+		result.Warnings = append(result.Warnings, "summary unavailable: "+err.Error())
+		return
+	}
 
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
+	result.Summary = summary
+	result.Stdout = truncateStdout(result.Stdout)
+
+	logger.DebugContext(ctx, "k6 summary export parsed",
+		slog.Int("metric_count", len(summary.Metrics)),
+		slog.Int("threshold_count", len(summary.Thresholds)))
+}
+
+func readSummaryExport(path string) (*RunSummary, error) {
+	//nolint:forbidigo // Reading the summary file written by k6 is required
+	// #nosec G304 -- path is a temp file created by this process
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read summary export: %w", err)
+	}
+	if len(strings.TrimSpace(string(content))) == 0 {
+		return nil, errors.New("k6 did not write a summary export")
+	}
+
+	return parseSummaryExport(content)
+}
+
+func parseSummaryExport(content []byte) (*RunSummary, error) {
+	var export struct {
+		Metrics map[string]map[string]json.RawMessage `json:"metrics"`
+	}
+	if err := json.Unmarshal(content, &export); err != nil {
+		return nil, fmt.Errorf("failed to parse summary export: %w", err)
+	}
+
+	summary := &RunSummary{Metrics: make(map[string]MetricSummary, len(export.Metrics))}
+
+	for name, fields := range export.Metrics {
+		metric := MetricSummary{Values: make(map[string]float64, len(fields))}
+
+		for key, raw := range fields {
+			if key == "thresholds" {
+				summary.Thresholds = append(summary.Thresholds, parseThresholds(name, raw)...)
+				continue
+			}
+
+			var value float64
+			if err := json.Unmarshal(raw, &value); err == nil {
+				metric.Values[key] = value
+			}
 		}
 
-		// Try to parse as JSON metric
-		var metric map[string]interface{}
-		if err := json.Unmarshal([]byte(line), &metric); err == nil {
-			jsonMetrics = append(jsonMetrics, metric)
+		metric.Type = inferMetricType(metric.Values)
+		summary.Metrics[name] = metric
+	}
+
+	sort.Slice(summary.Thresholds, func(i, j int) bool {
+		if summary.Thresholds[i].Metric != summary.Thresholds[j].Metric {
+			return summary.Thresholds[i].Metric < summary.Thresholds[j].Metric
+		}
+		return summary.Thresholds[i].Expression < summary.Thresholds[j].Expression
+	})
+
+	if checks, ok := summary.Metrics["checks"]; ok {
+		summary.Checks = &CheckSummary{
+			Passes: int(checks.Values["passes"]),
+			Fails:  int(checks.Values["fails"]),
 		}
 	}
 
-	// Store raw metrics from k6
-	if len(jsonMetrics) > 0 {
-		metrics["raw_metrics"] = jsonMetrics
-		metrics["metrics_count"] = len(jsonMetrics)
+	return summary, nil
+}
+
+// k6 exports each threshold as expression -> crossed, so true means the threshold failed.
+func parseThresholds(metric string, raw json.RawMessage) []ThresholdResult {
+	var crossed map[string]bool
+	if err := json.Unmarshal(raw, &crossed); err != nil {
+		return nil
 	}
 
-	return metrics
+	results := make([]ThresholdResult, 0, len(crossed))
+	for expression, failed := range crossed {
+		results = append(results, ThresholdResult{
+			Metric:     metric,
+			Expression: expression,
+			Passed:     !failed,
+		})
+	}
+
+	return results
+}
+
+// The legacy summary export omits metric types, so they are inferred from the value keys k6 emits.
+func inferMetricType(values map[string]float64) string {
+	_, hasCount := values["count"]
+	_, hasAvg := values["avg"]
+	_, hasPasses := values["passes"]
+	_, hasValue := values["value"]
+
+	switch {
+	case hasAvg:
+		return "trend"
+	case hasPasses:
+		return "rate"
+	case hasCount:
+		return "counter"
+	case hasValue:
+		return "gauge"
+	default:
+		return ""
+	}
+}
+
+func truncateStdout(stdout string) string {
+	if len(stdout) <= MaxStdoutPreviewBytes {
+		return stdout
+	}
+
+	cut := MaxStdoutPreviewBytes
+	for cut > 0 && !utf8.RuneStart(stdout[cut]) {
+		cut--
+	}
+
+	return stdout[:cut] + fmt.Sprintf(
+		"\n[stdout truncated to %d bytes; see summary for the full end-of-test results]",
+		MaxStdoutPreviewBytes,
+	)
+}
+
+func exitReason(exitCode int) string {
+	switch exitCode {
+	case 0:
+		return "success"
+	case int(exitcodes.ThresholdsHaveFailed):
+		return "thresholds_failed"
+	case int(exitcodes.SetupTimeout):
+		return "setup_timeout"
+	case int(exitcodes.TeardownTimeout):
+		return "teardown_timeout"
+	case int(exitcodes.GenericTimeout):
+		return "timeout"
+	case int(exitcodes.ScriptStoppedFromRESTAPI):
+		return "stopped_from_rest_api"
+	case int(exitcodes.InvalidConfig):
+		return "invalid_config"
+	case int(exitcodes.ExternalAbort):
+		return "external_abort"
+	case int(exitcodes.CannotStartRESTAPI):
+		return "cannot_start_rest_api"
+	case int(exitcodes.ScriptException):
+		return "script_exception"
+	case int(exitcodes.ScriptAborted):
+		return "script_aborted"
+	case int(exitcodes.GoPanic):
+		return "go_panic"
+	case int(exitcodes.MarkedAsFailed):
+		return "marked_as_failed"
+	case int(exitcodes.CloudTestRunFailed):
+		return "cloud_test_run_failed"
+	case int(exitcodes.CloudFailedToGetProgress):
+		return "cloud_failed_to_get_progress"
+	default:
+		return "unknown"
+	}
 }
 
 // sanitizeRunOptions removes sensitive information from run options for logging
@@ -602,9 +790,20 @@ func generateRunNextSteps(result *RunResult, options *RunOptions) []string {
 
 	var steps []string
 
+	if result.ThresholdsFailed {
+		steps = append(steps, "Inspect summary.thresholds to see which threshold expressions failed")
+		steps = append(steps,
+			"Compare the failing expressions against the values in summary.metrics to gauge how far off they are")
+		if !isMinimalRunOptions(options) {
+			steps = append(steps, "Use run_script with 1 VU and 1 iteration to check whether the thresholds fail without load")
+		}
+
+		return steps
+	}
+
 	// Handle test failures
 	if !result.Success || result.ExitCode != 0 {
-		steps = append(steps, "Use validate_k6_script to check for syntax errors and script validity")
+		steps = append(steps, "Use validate_script to check for syntax errors and script validity")
 		steps = append(steps, "Use stderr output above to identify specific error messages")
 
 		if result.ExitCode != 0 {
@@ -614,24 +813,26 @@ func generateRunNextSteps(result *RunResult, options *RunOptions) []string {
 		if options != nil &&
 			((options.VUs.Valid && options.VUs.Int64 > 1) ||
 				(options.Iterations.Valid && options.Iterations.Int64 > 1)) {
-			steps = append(steps, "Use run_k6_script with 1 VU and 1 iteration to isolate the issue")
+			steps = append(steps, "Use run_script with 1 VU and 1 iteration to isolate the issue")
 		}
 
 		return steps
 	}
 
 	// Successful execution
-	steps = append(steps, "Use the metrics data above to analyze test performance and results")
+	steps = append(steps, "Use the summary above to analyse test performance and results")
 
 	// Suggest scaling if using minimal configuration
 	if isMinimalRunOptions(options) {
-		steps = append(steps, "Use run_k6_script with higher VUs or iterations for comprehensive load testing")
-		steps = append(steps, "Use search_k6_docs to learn about advanced testing patterns and scenarios")
+		steps = append(steps, "Use run_script with higher VUs or iterations for comprehensive load testing")
+		steps = append(steps,
+			"Use list_sections and get_documentation to learn about advanced testing patterns and scenarios")
 	} else {
-		steps = append(steps, "Use search_k6_docs to explore advanced k6 features and optimization techniques")
+		steps = append(steps,
+			"Use list_sections and get_documentation to explore advanced k6 features and optimisation techniques")
 	}
 
-	steps = append(steps, "Use k6_info to discover additional k6 capabilities and features")
+	steps = append(steps, "Use info to discover the k6 version and environment in use")
 
 	return steps
 }

--- a/tools/run_test.go
+++ b/tools/run_test.go
@@ -12,14 +12,19 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/lib/types"
 	"gopkg.in/guregu/null.v3"
 )
+
+const summaryFixturePath = "testdata/summary_export.json"
 
 func TestBuildK6Args(t *testing.T) {
 	t.Parallel()
 
 	scriptPath := "script.js"
+	summaryPath := "summary.json"
+	summaryFlag := "--summary-export=" + summaryPath
 
 	tests := []struct {
 		name    string
@@ -29,12 +34,12 @@ func TestBuildK6Args(t *testing.T) {
 		{
 			name:    "nil options only pass script",
 			options: nil,
-			want:    []string{"run", scriptPath},
+			want:    []string{"run", summaryFlag, scriptPath},
 		},
 		{
 			name:    "empty options only pass script",
 			options: &RunOptions{},
-			want:    []string{"run", scriptPath},
+			want:    []string{"run", summaryFlag, scriptPath},
 		},
 		{
 			name: "zero numeric values are treated as unset",
@@ -42,7 +47,7 @@ func TestBuildK6Args(t *testing.T) {
 				VUs:        null.IntFrom(0),
 				Iterations: null.IntFrom(0),
 			},
-			want: []string{"run", scriptPath},
+			want: []string{"run", summaryFlag, scriptPath},
 		},
 		{
 			name: "explicit vus and duration are passed",
@@ -50,7 +55,7 @@ func TestBuildK6Args(t *testing.T) {
 				VUs:      null.IntFrom(10),
 				Duration: types.NullDurationFrom(30 * time.Second),
 			},
-			want: []string{"run", "--vus", "10", "--duration", "30s", scriptPath},
+			want: []string{"run", summaryFlag, "--vus", "10", "--duration", "30s", scriptPath},
 		},
 		{
 			name: "iterations take precedence over duration",
@@ -59,7 +64,7 @@ func TestBuildK6Args(t *testing.T) {
 				Duration:   types.NullDurationFrom(30 * time.Second),
 				Iterations: null.IntFrom(5),
 			},
-			want: []string{"run", "--vus", "2", "--iterations", "5", scriptPath},
+			want: []string{"run", summaryFlag, "--vus", "2", "--iterations", "5", scriptPath},
 		},
 	}
 
@@ -67,9 +72,131 @@ func TestBuildK6Args(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, tt.want, buildK6Args(scriptPath, tt.options))
+			require.Equal(t, tt.want, buildK6Args(scriptPath, summaryPath, tt.options))
 		})
 	}
+}
+
+func TestParseSummaryExport(t *testing.T) {
+	t.Parallel()
+
+	//nolint:forbidigo // Test reads a checked-in fixture
+	content, err := os.ReadFile(summaryFixturePath)
+	require.NoError(t, err)
+
+	summary, err := parseSummaryExport(content)
+	require.NoError(t, err)
+
+	require.Len(t, summary.Metrics, 7)
+	require.Equal(t, "trend", summary.Metrics["iteration_duration"].Type)
+	require.InDelta(t, 0.718042, summary.Metrics["iteration_duration"].Values["p(95)"], 1e-9)
+	require.Equal(t, "counter", summary.Metrics["iterations"].Type)
+	require.InDelta(t, 1, summary.Metrics["iterations"].Values["count"], 0)
+	require.Equal(t, "rate", summary.Metrics["checks"].Type)
+	require.InDelta(t, 0.5, summary.Metrics["checks"].Values["value"], 0)
+	require.Equal(t, "gauge", summary.Metrics["vus"].Type)
+	require.NotContains(t, summary.Metrics["checks"].Values, "thresholds")
+
+	require.Equal(t, []ThresholdResult{
+		{Metric: "checks", Expression: "rate>0.5", Passed: false},
+		{Metric: "iterations", Expression: "count>=1", Passed: true},
+		{Metric: "my_counter", Expression: "count<1", Passed: false},
+	}, summary.Thresholds)
+
+	require.Equal(t, &CheckSummary{Passes: 1, Fails: 1}, summary.Checks)
+}
+
+func TestParseSummaryExportWithoutChecksOrThresholds(t *testing.T) {
+	t.Parallel()
+
+	summary, err := parseSummaryExport([]byte(`{"metrics":{"iterations":{"count":2,"rate":4}}}`))
+	require.NoError(t, err)
+	require.Nil(t, summary.Checks)
+	require.Empty(t, summary.Thresholds)
+	require.Equal(t, "counter", summary.Metrics["iterations"].Type)
+}
+
+func TestReadSummaryExport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+
+		summary, err := readSummaryExport(filepath.Join(t.TempDir(), "missing.json"))
+		require.Nil(t, summary)
+		require.ErrorContains(t, err, "failed to read summary export")
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		t.Parallel()
+
+		summary, err := readSummaryExport(writeTempFile(t, ""))
+		require.Nil(t, summary)
+		require.ErrorContains(t, err, "did not write a summary export")
+	})
+
+	t.Run("malformed file", func(t *testing.T) {
+		t.Parallel()
+
+		summary, err := readSummaryExport(writeTempFile(t, "{not json"))
+		require.Nil(t, summary)
+		require.ErrorContains(t, err, "failed to parse summary export")
+	})
+}
+
+func TestExitReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		code int
+		want string
+	}{
+		{code: 0, want: "success"},
+		{code: int(exitcodes.ThresholdsHaveFailed), want: "thresholds_failed"},
+		{code: int(exitcodes.SetupTimeout), want: "setup_timeout"},
+		{code: int(exitcodes.TeardownTimeout), want: "teardown_timeout"},
+		{code: int(exitcodes.ScriptException), want: "script_exception"},
+		{code: int(exitcodes.ScriptAborted), want: "script_aborted"},
+		{code: int(exitcodes.InvalidConfig), want: "invalid_config"},
+		{code: 1, want: "unknown"},
+		{code: -1, want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, exitReason(tt.code))
+		})
+	}
+}
+
+func TestTruncateStdout(t *testing.T) {
+	t.Parallel()
+
+	short := strings.Repeat("a", MaxStdoutPreviewBytes)
+	require.Equal(t, short, truncateStdout(short))
+
+	long := strings.Repeat("a", MaxStdoutPreviewBytes-1) + "µ" + strings.Repeat("b", 100)
+	truncated := truncateStdout(long)
+	require.True(t, strings.HasPrefix(truncated, strings.Repeat("a", MaxStdoutPreviewBytes-1)))
+	require.Contains(t, truncated, "[stdout truncated to 4096 bytes")
+	require.NotContains(t, truncated, "µ")
+	require.NotContains(t, truncated, "bbb")
+}
+
+func TestGenerateRunNextStepsForThresholdFailure(t *testing.T) {
+	t.Parallel()
+
+	steps := generateRunNextSteps(&RunResult{
+		Success:          false,
+		ExitCode:         int(exitcodes.ThresholdsHaveFailed),
+		ThresholdsFailed: true,
+	}, &RunOptions{VUs: null.IntFrom(5)})
+
+	require.Contains(t, steps[0], "summary.thresholds")
+	require.Contains(t, strings.Join(steps, "\n"), "run_script with 1 VU and 1 iteration")
+	require.NotContains(t, strings.Join(steps, "\n"), "validate_script")
 }
 
 const emptyDefaultExportScript = "export default function() {}"
@@ -189,12 +316,44 @@ func TestRunK6TestDoesNotInjectUnsetWorkloadArgs(t *testing.T) {
 	result, err := RunK6Test(context.Background(), scenarioScript(), &RunOptions{})
 	require.NoError(t, err)
 	require.True(t, result.Success)
+	require.Equal(t, "success", result.ExitReason)
+	require.Nil(t, result.Summary)
+	require.Equal(t, []string{"summary unavailable: k6 did not write a summary export"}, result.Warnings)
 
 	args := readRecordedArgs(t, argsPath)
 	require.Equal(t, "run", args[0])
 	require.NotContains(t, args, "--vus")
 	require.NotContains(t, args, "--duration")
 	require.NotContains(t, args, "--iterations")
+}
+
+func TestRunK6TestReportsThresholdFailureWithSummary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("recording shell stub is Unix-only")
+	}
+
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	fixturePath, err := filepath.Abs(summaryFixturePath)
+	require.NoError(t, err)
+	createSummaryWritingK6Stub(t, dir, argsPath, fixturePath, int(exitcodes.ThresholdsHaveFailed))
+	t.Setenv("PATH", dir)
+
+	result, err := RunK6Test(context.Background(), scenarioScript(), &RunOptions{})
+	require.NoError(t, err)
+	require.False(t, result.Success)
+	require.True(t, result.ThresholdsFailed)
+	require.Equal(t, "thresholds_failed", result.ExitReason)
+	require.Equal(t, "k6 test failed with exit code 99", result.Error)
+	require.Empty(t, result.Warnings)
+	require.NotNil(t, result.Summary)
+	require.Len(t, result.Summary.Thresholds, 3)
+	require.Contains(t, result.NextSteps[0], "summary.thresholds")
+	require.Contains(t, result.Stdout, "[stdout truncated to")
+
+	args := readRecordedArgs(t, argsPath)
+	require.True(t, strings.HasPrefix(args[1], "--summary-export="))
+	require.NoFileExists(t, strings.TrimPrefix(args[1], "--summary-export="))
 }
 
 func TestRunK6TestPassesExplicitWorkloadArgs(t *testing.T) {
@@ -216,7 +375,9 @@ func TestRunK6TestPassesExplicitWorkloadArgs(t *testing.T) {
 	require.True(t, result.Success)
 
 	args := readRecordedArgs(t, argsPath)
-	require.Equal(t, []string{"run", "--vus", "3", "--iterations", "1"}, args[:5])
+	require.Equal(t, "run", args[0])
+	require.True(t, strings.HasPrefix(args[1], "--summary-export="))
+	require.Equal(t, []string{"--vus", "3", "--iterations", "1"}, args[2:6])
 	require.NotContains(t, args, "--duration")
 }
 
@@ -239,6 +400,38 @@ func createRecordingK6Stub(t *testing.T, dir, argsPath string) {
 	//nolint:forbidigo // Adjust permissions for executable stub
 	// #nosec G302 -- Stub executable must be runnable during tests
 	require.NoError(t, os.Chmod(path, 0o700))
+}
+
+func createSummaryWritingK6Stub(t *testing.T, dir, argsPath, fixturePath string, exitCode int) {
+	t.Helper()
+
+	content := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$@" > %s
+for arg in "$@"; do
+  case "$arg" in
+    --summary-export=*) /bin/cp %s "${arg#--summary-export=}" ;;
+  esac
+done
+i=0
+while [ $i -le %d ]; do printf 'x'; i=$((i+1)); done
+exit %d
+`, shellQuote(argsPath), shellQuote(fixturePath), MaxStdoutPreviewBytes, exitCode)
+	path := filepath.Join(dir, "k6")
+	//nolint:forbidigo // Test helper requires writing stub executable
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	//nolint:forbidigo // Adjust permissions for executable stub
+	// #nosec G302 -- Stub executable must be runnable during tests
+	require.NoError(t, os.Chmod(path, 0o700))
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "summary.json")
+	//nolint:forbidigo // Test helper writes a fixture file
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
 }
 
 func readRecordedArgs(t *testing.T, argsPath string) []string {

--- a/tools/testdata/summary_export.json
+++ b/tools/testdata/summary_export.json
@@ -1,0 +1,62 @@
+{
+    "metrics": {
+        "my_counter": {
+            "count": 1,
+            "rate": 621.1180124223602,
+            "thresholds": {
+                "count<1": true
+            }
+        },
+        "data_sent": {
+            "count": 0,
+            "rate": 0
+        },
+        "data_received": {
+            "count": 0,
+            "rate": 0
+        },
+        "iteration_duration": {
+            "med": 0.718042,
+            "max": 0.718042,
+            "p(90)": 0.718042,
+            "p(95)": 0.718042,
+            "avg": 0.718042,
+            "min": 0.718042
+        },
+        "vus": {
+            "value": 1,
+            "min": 1,
+            "max": 1
+        },
+        "checks": {
+            "passes": 1,
+            "fails": 1,
+            "thresholds": {
+                "rate>0.5": true
+            },
+            "value": 0.5
+        },
+        "iterations": {
+            "count": 1,
+            "rate": 621.1180124223602,
+            "thresholds": {
+                "count>=1": false
+            }
+        }
+    },
+    "root_group": {
+        "groups": {},
+        "checks": {
+            "ok": {
+                "passes": 1,
+                "fails": 0,
+                "name": "ok",
+                "path": "::ok",
+                "id": "2385b52f13b6c5244d846734f1757fa3"
+            }
+        },
+        "name": "",
+        "path": "",
+        "id": "d41d8cd98f00b204e9800998ecf8427e"
+    }
+}

--- a/tools/validate.go
+++ b/tools/validate.go
@@ -154,7 +154,7 @@ func validateK6Script(ctx context.Context, script string) (*ValidationResponse, 
 	})
 
 	// Create secure temporary file
-	tempFile, cleanup, err := createSecureTempFile(script)
+	tempFile, cleanup, err := createSecureTempFile(scriptTempFilePattern, script)
 	if err != nil {
 		logging.FileOperation(ctx, "validator", "create_temp_file", tempFile, err)
 		return &ValidationResponse{


### PR DESCRIPTION
run_script previously tried to parse stdout as JSON lines, so its metrics field was always empty, and it skipped parsing entirely on a non-zero exit code. Threshold failures, which exit with 99, therefore returned no numbers at all.

k6 now writes its summary to a secure temp file via --summary-export and the file is parsed regardless of exit code. The untyped metrics map is replaced by a summary field containing metrics (inferred type plus the raw k6 values), thresholds (k6's crossed flag normalised into passed) and checks. Two new fields describe the outcome: thresholds_failed, set when the exit code matches exitcodes.ThresholdsHaveFailed, and exit_reason, which maps known k6 exit codes to short labels. success still means exit code 0. A summary that is missing or malformed adds a warnings entry instead of failing the call.

Once a summary is attached, stdout is cut to a 4 KiB preview with an inline note; stderr is left intact. Next steps now direct the caller to summary.thresholds after a threshold failure and use the real tool names.

createSecureTempFile takes a pattern and content so the summary file shares the existing 0600 temp file handling and cleanup. Unit tests cover fixture parsing, threshold polarity, exit code mapping, missing file handling and truncation. The e2e suite gains a deliberate threshold failure, and the README documents the new fields.

The flag and threshold polarity were verified against k6 v1.1.0, v1.7.0 and v2.2.0. The last is the version pinned in go.mod, which the Dockerfile builds and ships in place of the base image's k6. In the exported JSON, true means the threshold was crossed.

Known limitation:

Scripts that export their own handleSummary replace k6's default summary handler, which is what writes the --summary-export file. Such runs return a warnings entry and no summary even on success. Moving to a handleSummary based capture is the longer-term fix and would also remove the dependency on a flag k6 now treats as legacy.

Testing notes:

The full e2e file fails locally at the pre-existing info tool test on k6 v1.1.0 before reaching the new case. That is the behaviour described in #153, with a fix in #154, and is unrelated to this change. The run_script cases pass when run in isolation.